### PR TITLE
Fix cluster tag not being sent to new worker applications

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1912,12 +1912,10 @@ def create_cluster_tag():
 
 @when('leadership.set.cluster_tag',
       'kube-control.connected')
-@when_not('kubernetes-master.cluster-tag-sent')
 def send_cluster_tag():
     cluster_tag = leader_get('cluster_tag')
     kube_control = endpoint_from_flag('kube-control.connected')
     kube_control.set_cluster_tag(cluster_tag)
-    set_state('kubernetes-master.cluster-tag-sent')
 
 
 @when_not('kube-control.connected')


### PR DESCRIPTION
Fixes [lp:1824361](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1824361)

When using CDK with the AWS integrator, if a new worker application is
added to a running cluster, the masters will never send the cluster tag
to the new workers, which prevents the cloud integration with the new
workers from completing. They workers will get stuck in a "Waiting for
cloud integration" status.

This change removes the state that says, "I've already sent the cluster
tag, never send it again," thereby allowing the cluster tag to be sent
to new worker applications that join the cluster.