### PR TITLE
Adding support for setting the virtual IP that points to the control plane

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -267,13 +267,12 @@ options:
   loadbalancer-ips:
     type: string
     description: |
-      Space seperated list of IP addresses of loadbalancers in front of control plane.
-      These can be either virtual IP addresses that are floated in front of the control
-      plane or the IP of a loadbalancer such as an F5. The workers will alternate IP
-      addresses from this list to distribute load. If you have 2 IPs and 4 workers,
-      each IP will be used by 2 workers. Note that this will only work if there is a
-      relation between kubernetes-master:kube-api-endpoint and
-      kubernetes-worker:kube-api-endpoint. This is the case if kubeapi-load-balancer
-      is not in use. If it is, use the loadbalancer-ips configuration variable on
-      the kubeapi-load-balancer charm.
+      Space separated list of IP addresses of loadbalancers in front of the control plane.
+      These can be either virtual IP addresses that have been floated in front of the control
+      plane or the IP of a loadbalancer appliance such as an F5. Workers will alternate IP
+      addresses from this list to distribute load - for example If you have 2 IPs and 4 workers,
+      each IP will be used by 2 workers. Note that this will only work if kubeapi-load-balancer
+      is not in use and there is a relation between kubernetes-master:kube-api-endpoint and
+      kubernetes-worker:kube-api-endpoint. If using the kubeapi-load-balancer, see the
+      loadbalancer-ips configuration variable on the kubeapi-load-balancer charm.
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -264,3 +264,12 @@ options:
       "basic", and "token". If set to "auto", basic auth is used unless Keystone is 
       related to kubernetes-master, in which case token auth is used.
     default: "auto"
+  loadbalancer-ips:
+    type: string
+    description: |
+      Space seperated list of IP addresses of loadbalancers in front of control plane.
+      These can be either virtual IP addresses that are floated in front of the control
+      plane or the IP of a loadbalancer such as an F5. The workers will alternate IP
+      addresses from this list to distribute load. If you have 2 IPs and 4 workers,
+      each IP will be used by 2 workers.
+    default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -271,5 +271,9 @@ options:
       These can be either virtual IP addresses that are floated in front of the control
       plane or the IP of a loadbalancer such as an F5. The workers will alternate IP
       addresses from this list to distribute load. If you have 2 IPs and 4 workers,
-      each IP will be used by 2 workers.
+      each IP will be used by 2 workers. Note that this will only work if there is a
+      relation between kubernetes-master:kube-api-endpoint and
+      kubernetes-worker:kube-api-endpoint. This is the case if kubeapi-load-balancer
+      is not in use. If it is, use the loadbalancer-ips configuration variable on
+      the kubeapi-load-balancer charm.
     default: ""

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1030,11 +1030,6 @@ def loadbalancer_kubeconfig():
         if hacluster_vip:
             address = hacluster_vip
         else:
-            if len(hosts) < 1:
-                # oops...hopefully we just lost our relation.
-                # skip this for now.
-                return
-
             # Get the public address of the first loadbalancer so
             # users can access the cluster.
             address = hosts[0].get('public-address')
@@ -2339,15 +2334,3 @@ def get_dns_provider():
 
     leader_set(auto_dns_provider=dns_provider)
     return dns_provider
-
-
-@when('config.changed.loadbalancer-ips')
-def vip_changed():
-    # get a new cert
-    if (is_state('certificates.available') and
-            is_state('kube-api-endpoint.available')):
-        send_data()
-
-    # update workers
-    if (is_state('kube-api-endpoint.available')):
-        push_service_data()

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1034,7 +1034,7 @@ def loadbalancer_kubeconfig():
             if len(hosts) < 1:
                 # oops...hopefully we just lost our relation.
                 # skip this for now.
-            return
+                return
 
             # Get the public address of the first loadbalancer so
             # users can access the cluster.

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -795,18 +795,17 @@ def push_service_data():
     # what they are talking about and use that instead of our information.
     address = None
     forced_lb_ips = hookenv.config('loadbalancer-ips').split()
+    hacluster = endpoint_from_flag('ha.connected')
     if forced_lb_ips:
-        address = forced_lb_ips[get_unit_number() % len(forced_lb_ips)]
-    else:
-        hacluster = endpoint_from_flag('ha.connected')
-        if hacluster:
-            vips = hookenv.config('ha-cluster-vip').split()
-            dns_record = hookenv.config('ha-cluster-dns')
-            if vips:
-                # each worker unit will pick one based on unit number
-                address = vips
-            elif dns_record:
-                address = dns_record
+        address = forced_lb_ips
+    elif hacluster:
+        vips = hookenv.config('ha-cluster-vip').split()
+        dns_record = hookenv.config('ha-cluster-dns')
+        if vips:
+            # each worker unit will pick one based on unit number
+            address = vips
+        elif dns_record:
+            address = dns_record
 
     if address:
         kube_api.configure(6443, address, address)


### PR DESCRIPTION
This allows for someone with an external load balancer to specify the IP that the workers will use to talk to the control plane.