### PR TITLE
Fix stucking at "Waiting for master components to start" after upgrading

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -308,7 +308,6 @@ def install_snaps():
     calculate_and_store_resource_checksums(checksum_prefix, snap_resources)
     db.set('snap.resources.fingerprint.initialised', True)
     set_state('kubernetes-master.snaps.installed')
-    remove_state('kubernetes-master.components.started')
 
 
 @when('config.changed.client_password', 'leadership.is_leader')


### PR DESCRIPTION
install_snap() removes flag kubernetes-master.components.started
but there is no set it back.

so status is stuck at "Waiting for master components to start"

##
I just removed it but if there is proper way, Please advice me.

Thanks