### PR TITLE
Make setup_basic_auth() non-destructive.

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1736,18 +1736,18 @@ def setup_basic_auth(password=None, username='admin', uid='admin',
     # If we have an existing line for this username, update it, leaving
     # lines for other users unchanged.
     with fileinput.input(htaccess, inplace=True) as f:
-        user_written = False
+        wrote_user_line = False
 
         for line in f:
             line_user, line_uid = line.split(',')[1:3]
             if (line_user, line_uid) == (username, uid):
                 print(newline)
-                user_written = True
+                wrote_user_line = True
             else:
                 print(line.strip())
 
     # If we didn't find an existing line for this username, add one.
-    if not user_written:
+    if not wrote_user_line:
         with open(htaccess, 'a') as f:
             f.write(newline)
 

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import base64
-import fileinput
+import csv
 import os
 import re
 import random
@@ -672,7 +672,6 @@ def add_systemd_file_watcher():
         'cdk.master.leader.file-watcher.path',
         '/etc/systemd/system/cdk.master.leader.file-watcher.path',
         {}, perms=0o644)
-    service_resume('cdk.master.leader.file-watcher.service')
     service_resume('cdk.master.leader.file-watcher.path')
 
 
@@ -1749,34 +1748,28 @@ def configure_scheduler():
 def setup_basic_auth(password=None, username='admin', uid='admin',
                      groups=None):
     '''Add or update an entry in /root/cdk/basic_auth.csv.'''
-    root_cdk = '/root/cdk'
-    if not os.path.isdir(root_cdk):
-        os.makedirs(root_cdk)
-    htaccess = os.path.join(root_cdk, 'basic_auth.csv')
+    htaccess = Path('/root/cdk/basic_auth.csv')
+    htaccess.parent.mkdir(parents=True, exist_ok=True)
+
     if not password:
         password = token_generator()
 
-    newline = '{0},{1},{2}'.format(password, username, uid)
-    if groups:
-        newline += ',"{0}"'.format(groups)
+    new_row = [password, username, uid] + ([groups] if groups else [])
 
-    # If we have an existing line for this username, update it, leaving
-    # lines for other users unchanged.
-    with fileinput.input(htaccess, inplace=True) as f:
-        wrote_user_line = False
+    with htaccess.open('r') as f:
+        rows = list(csv.reader(f))
 
-        for line in f:
-            line_user, line_uid = line.split(',')[1:3]
-            if (line_user, line_uid) == (username, uid):
-                print(newline)
-                wrote_user_line = True
-            else:
-                print(line.strip())
+    for row in rows:
+        if row[1] == username or row[2] == uid:
+            # update existing entry based on username or uid
+            row[:] = new_row
+            break
+    else:
+        # append new entry
+        rows.append(new_row)
 
-    # If we didn't find an existing line for this username, add one.
-    if not wrote_user_line:
-        with open(htaccess, 'a') as f:
-            f.write(newline)
+    with htaccess.open('w') as f:
+        csv.writer(f).writerows(rows)
 
 
 def setup_tokens(token, username, user, groups=None):

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -660,13 +660,16 @@ def add_systemd_file_watcher():
     non-leaders so they can sync their local copies to match.
 
     """
-    render('cdk.master.leader.file-watcher.sh',
+    render(
+        'cdk.master.leader.file-watcher.sh',
         '/usr/local/sbin/cdk.master.leader.file-watcher.sh',
         {}, perms=0o777)
-    render('cdk.master.leader.file-watcher.service',
+    render(
+        'cdk.master.leader.file-watcher.service',
         '/etc/systemd/system/cdk.master.leader.file-watcher.service',
         {'unit': hookenv.local_unit()}, perms=0o644)
-    render('cdk.master.leader.file-watcher.path',
+    render(
+        'cdk.master.leader.file-watcher.path',
         '/etc/systemd/system/cdk.master.leader.file-watcher.path',
         {}, perms=0o644)
     service_resume('cdk.master.leader.file-watcher.service')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import base64
+import fileinput
 import os
 import re
 import random
@@ -1720,19 +1721,35 @@ def configure_scheduler():
 
 def setup_basic_auth(password=None, username='admin', uid='admin',
                      groups=None):
-    '''Create the htacces file and the tokens.'''
+    '''Add or update an entry in /root/cdk/basic_auth.csv.'''
     root_cdk = '/root/cdk'
     if not os.path.isdir(root_cdk):
         os.makedirs(root_cdk)
     htaccess = os.path.join(root_cdk, 'basic_auth.csv')
     if not password:
         password = token_generator()
-    with open(htaccess, 'w') as stream:
-        if groups:
-            stream.write('{0},{1},{2},"{3}"'.format(password,
-                                                    username, uid, groups))
-        else:
-            stream.write('{0},{1},{2}'.format(password, username, uid))
+
+    newline = '{0},{1},{2}'.format(password, username, uid)
+    if groups:
+        newline += ',"{0}"'.format(groups)
+
+    # If we have an existing line for this username, update it, leaving
+    # lines for other users unchanged.
+    with fileinput.input(htaccess, inplace=True) as f:
+        user_written = False
+
+        for line in f:
+            line_user, line_uid = line.split(',')[1:3]
+            if (line_user, line_uid) == (username, uid):
+                print(newline)
+                user_written = True
+            else:
+                print(line.strip())
+
+    # If we didn't find an existing line for this username, add one.
+    if not user_written:
+        with open(htaccess, 'a') as f:
+            f.write(newline)
 
 
 def setup_tokens(token, username, user, groups=None):

--- a/templates/cdk.master.leader.file-watcher.path
+++ b/templates/cdk.master.leader.file-watcher.path
@@ -1,0 +1,7 @@
+[Path]
+PathChanged=/root/cdk/basic_auth.csv
+PathChanged=/root/cdk/known_tokens.csv
+PathChanged=/root/cdk/serviceaccount.key
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/cdk.master.leader.file-watcher.service
+++ b/templates/cdk.master.leader.file-watcher.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=CDK master leader file-watcher
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/juju-run {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/cdk.master.leader.file-watcher.sh
+++ b/templates/cdk.master.leader.file-watcher.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is invoked by cdk.master.leader.file-watcher.service
+
+if [ is-leader ]; then
+  leader-set \
+    "/root/cdk/basic_auth.csv=$(cat /root/cdk/basic_auth.csv)" \
+    "/root/cdk/known_tokens.csv=$(cat /root/cdk/known_tokens.csv)" \
+    "/root/cdk/serviceaccount.key=$(cat /root/cdk/serviceaccount.key)"
+fi


### PR DESCRIPTION
Fixes [lp:1826260](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1826260)

This changes the behavior of setup_basic_auth(). Instead of overwriting
the entire /root/cdk/basic_auth.csv file and replacing it with a single
line, it will now:

1. Update a single line if the file already contains an entry for
`username`.
2. Add a single line if the file does not already contain an entry
for `username`.