### PR TITLE
Fix kubelet-preferred-address-types set incorrectly

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1518,7 +1518,7 @@ def configure_apiserver(etcd_connection_string):
     api_opts['token-auth-file'] = '/root/cdk/known_tokens.csv'
     api_opts['service-account-key-file'] = '/root/cdk/serviceaccount.key'
     api_opts['kubelet-preferred-address-types'] = \
-        '[InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP]'
+        'InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP'
     api_opts['advertise-address'] = get_ingress_address('kube-control')
 
     etcd_dir = '/root/cdk/etcd'


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1826397

@johnsca should be able to vouch for this as a fix for `kubectl logs` failing on openstack.

Some additional evidence: [kubelet-preferred-address-types in the Kubernetes code](https://github.com/kubernetes/kubernetes/blob/b7394102d6ef778017f2ca4046abbaa23b88c290/cmd/kube-apiserver/app/options/options.go#L190) is defined using StringSliceVar. Kubernetes uses [Cobra](https://github.com/spf13/cobra), which uses [pflag](https://github.com/spf13/pflag), which documents StringSliceVar [here](https://godoc.org/github.com/spf13/pflag#StringSliceVar). No brackets.