### PR TITLE
Make SANs list more consistent

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -881,7 +881,7 @@ def send_data():
         sans.extend(extra_sans.split())
 
     # Request a server cert with this information.
-    tls_client.request_server_cert(common_name, sans,
+    tls_client.request_server_cert(common_name, sorted(set(sans)),
                                    crt_path=server_crt_path,
                                    key_path=server_key_path)
 


### PR DESCRIPTION
Remove duplicates and ensure consistent ordering of SANs list.  This prevents unnecessary relation hooks and cert regeneration.

Fixes [lp:1826625](https://bugs.launchpad.net/charm-easyrsa/+bug/1826625)
See also: https://github.com/juju-solutions/interface-tls-certificates/pull/17
See also: https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/9