### PR TITLE
[stable] Prevent to remove /srv/kubernetes directory when upgrading

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -266,7 +266,6 @@ def migrate_from_pre_snaps():
         "/etc/default/kube-apiserver.defaults",
         "/etc/default/kube-controller-manager.defaults",
         "/etc/default/kube-scheduler.defaults",
-        "/srv/kubernetes",
         "/home/ubuntu/kubectl",
         "/usr/local/bin/kubectl",
         "/usr/local/bin/kube-apiserver",


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1825288 in stable branch.

Cherry-pick of https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/11