### PR TITLE
Configure master with an image-registry

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,8 +50,8 @@ options:
       Specify the docker registry to use when applying addons.
 
       DEPRECATED in 1.15: Use the broader 'image-registry' config option instead. If both
-      options are set, addons-registry will take precedence during cdk-addons snap
-      configuration until v1.14 reaches EOL.
+      options are set, 'addons-registry' will be used to configure the cdk-addons snap until
+      v1.17 is released. After that, the 'addons-registry' option will have no effect.
   image-registry:
     type: string
     default: "image-registry.canonical.com:5000/cdk"

--- a/config.yaml
+++ b/config.yaml
@@ -43,10 +43,6 @@ options:
       Audit webhook config passed to kube-apiserver via --audit-webhook-config-file.
       For more info, please refer to the upstream documentation at
       https://kubernetes.io/docs/tasks/debug-application-cluster/audit/
-  addons-registry:
-    type: string
-    default: ""
-    description: Specify the docker registry to use when applying addons
   enable-dashboard-addons:
     type: boolean
     default: True
@@ -264,3 +260,10 @@ options:
       "basic", and "token". If set to "auto", basic auth is used unless Keystone is 
       related to kubernetes-master, in which case token auth is used.
     default: "auto"
+  image-registry:
+    type: string
+    description: |
+      Container image registry to use for CDK. This includes addons like the Kubernetes dashboard,
+      metrics server, ingress, and dns along with impacting the source location for the pause
+      container and default backend image.
+    default: "http://image-registry.canonical.com:5000/cdk"

--- a/config.yaml
+++ b/config.yaml
@@ -47,15 +47,18 @@ options:
     type: string
     default: ""
     description: |
-      DEPRECATED in 1.15: Specify the docker registry to use when applying addons.
-      For v1.15 and later, use the broader 'image-registry' config option instead.
+      Specify the docker registry to use when applying addons.
+
+      DEPRECATED in 1.15: Use the broader 'image-registry' config option instead. If both
+      options are set, addons-registry will take precedence during cdk-addons snap
+      configuration until v1.14 reaches EOL.
   image-registry:
     type: string
+    default: "image-registry.canonical.com:5000/cdk"
     description: |
       Container image registry to use for CDK. This includes addons like the Kubernetes dashboard,
       metrics server, ingress, and dns along with non-addon images including the pause
       container and default backend image.
-    default: "http://image-registry.canonical.com:5000/cdk"
   enable-dashboard-addons:
     type: boolean
     default: True

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2419,7 +2419,6 @@ def send_registry_location():
     set_flag('kubernetes-master.sent-registry')
 
 
-@when('kube-control.connected')
 @when('config.changed.image-registry')
 def send_new_registry_location():
     clear_flag('kubernetes-master.sent-registry')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -943,10 +943,10 @@ def configure_cdk_addons():
     gpuEnable = (get_version('kube-apiserver') >= (1, 9) and
                  load_gpu_plugin == "auto" and
                  is_state('kubernetes-master.gpu.enabled'))
-    # addons-registry is deprecated in 1.15, but it should still take
-    # precedent if set when configuring the cdk-addons snap.
+    # addons-registry is deprecated in 1.15, but it should take precedence
+    # when configuring the cdk-addons snap until 1.17 is released.
     registry = hookenv.config('addons-registry')
-    if registry:
+    if registry and get_version('kube-apiserver') < (1, 17):
         hookenv.log('addons-registry is deprecated; use image-registry instead')
     else:
         registry = hookenv.config('image-registry')


### PR DESCRIPTION
Per https://bugs.launchpad.net/charm-kubernetes-master/+bug/1828853, we have a few commits to cdkaddons and interface-kube-control that will facilitate a better way to configure a container registry for cdk.

Pick up where @hyperbolic2346 started to bring k8s-master in line with that vision.