### PR TITLE
Convert boolean to YAML 1.2-compliant format

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -61,7 +61,7 @@ options:
       container and default backend image.
   enable-dashboard-addons:
     type: boolean
-    default: True
+    default: true
     description: Deploy the Kubernetes Dashboard and Heapster addons
   dns-provider:
     type: string


### PR DESCRIPTION
YAML 1.2 drops support for the variety of boolean values that 1.1 allows, such as `True` or `TRUE`, in favor of simply `true` and `false`. The `True` here broke my 1.2-compliant-only parser