### PR TITLE
Fix debug action missing kubectl info when using keystone

### DIFF
--- a/debug-scripts/kubectl
+++ b/debug-scripts/kubectl
@@ -3,8 +3,6 @@ set -ux
 
 export PATH=$PATH:/snap/bin
 
-alias kubectl="kubectl --kubeconfig=/home/ubuntu/config"
-
 kubectl cluster-info > $DEBUG_SCRIPT_DIR/cluster-info
 kubectl cluster-info dump > $DEBUG_SCRIPT_DIR/cluster-info-dump
 for obj in pods svc ingress secrets pv pvc rc; do


### PR DESCRIPTION
The debug action failed to collect kubectl info when keystone was in use:
```
Unable to connect to the server: getting credentials: exec: fork/exec /snap/bin/client-keystone-auth: no such file or directory
```

This should hopefully fix it - don't bother using the kubeconfig at `/home/ubuntu/config`, which is meant for end users. Instead, use the kubeconfig from `/root/.kube/config` (default path) which is what the rest of the charm uses. It should work.