### PR TITLE
lp 1833089: only call leader_set when is_leader

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2406,7 +2406,10 @@ def get_dns_provider():
             else:
                 dns_provider = 'kube-dns'
 
-    leader_set(auto_dns_provider=dns_provider)
+    # LP: 1833089. Followers end up here when setting final status; ensure only
+    # leaders call leader_set.
+    if is_state('leadership.is_leader'):
+        leader_set(auto_dns_provider=dns_provider)
     return dns_provider
 
 


### PR DESCRIPTION
There's been a change in 2.6.4 that turned a warning into an error when followers attempted to call leader-set.  This led to:

https://bugs.launchpad.net/charm-kubernetes-master/+bug/1833089

`get_dns_provider` will be called by a follower during `set_final_status`. Ensure we only call `leader_set` if we're the leader. It's safe for followers to return from `get_dns_provider` without calling `leader_set` because:

- followers weren't actually setting leader data before now
- if no config nor leader_get data is available, the same logic is used for all units to set `dns_provider = core-dns`