### PR TITLE
Fix followers calling leader-set when using keystone

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -925,13 +925,6 @@ def kick_api_server():
     clear_flag('tls_client.certs.changed')
 
 
-@when_any('config.changed.keystone-policy',
-          'config.changed.keystone-ssl-ca')
-@when('keystone-credentials.available.auth')
-def regenerate_cdk_addons():
-    configure_cdk_addons()
-
-
 @when_any('kubernetes-master.components.started',
           'kubernetes-master.ceph.configured',
           'keystone-credentials.available.auth')


### PR DESCRIPTION
`configure_cdk_addons` is only supposed to be called by leaders, but `regenerate_cdk_addons` was giving followers a back door into it.

The `configure_cdk_addons` handler runs on every hook anyway. Fix this by removing `regenerate_cdk_addons`.