### PR TITLE
Handle updates to certs or CA info

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -745,6 +745,11 @@ def etcd_data_change(etcd):
     if data_changed('etcd-connect', connection_string):
         remove_state('kubernetes-master.components.started')
 
+    # If the cert info changes, remove the started state to trigger
+    # handling of the master components
+    if data_changed('etcd-certs', etcd.get_client_credentials()):
+        remove_state('kubernetes-master.components.started')
+
     # We are the leader and the auto_storage_backend is not set meaning
     # this is the first time we connect to etcd.
     auto_storage_backend = leader_get('auto_storage_backend')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2466,7 +2466,7 @@ def restart_addons_for_ca():
         service_accounts = []
         for namespace, name in service_account_names:
             output = kubectl(
-                'kubectl', 'get', 'ServiceAccount', name,
+                'get', 'ServiceAccount', name,
                 '-o', 'json',
                 '-n', namespace
             ).decode('UTF-8')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1860,9 +1860,14 @@ def token_generator(length=32):
     return token
 
 
-@retry(times=3, delay_secs=10)
+@retry(times=3, delay_secs=1)
 def get_pods(namespace='default'):
-    cmd = ['kubectl', 'get', 'po', '-n', namespace, '-o', 'json']
+    cmd = [
+        'kubectl', 'get', 'po',
+        '-n', namespace,
+        '-o', 'json',
+        '--request-timeout', '10s'
+    ]
     try:
         output = check_output(cmd).decode('utf-8')
         result = json.loads(output)

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -717,6 +717,17 @@ def start_master():
 
     set_state('kubernetes-master.components.started')
     hookenv.open_port(6443)
+    remove_state('tls_client.certs.changed')
+    remove_state('tls_client.ca.written')
+
+
+@when('kubernetes-master.components.started')
+@when_any('tls_client.certs.changed',
+          'tls_client.ca.written')
+def update_certs():
+    remove_state('kubernetes-master.components.started')
+    remove_state('tls_client.certs.changed')
+    remove_state('tls_client.ca.written')
 
 
 @when('etcd.available')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2445,18 +2445,15 @@ def send_new_registry_location():
 def restart_addons_for_ca():
     try:
         # Get deployments/daemonsets/statefulsets
-        labels = ['cdk-addons=true', 'cdk-ingress=true']
-        deployments = []
-        for label in labels:
-            cmd = [
-                'kubectl', 'get',
-                '-o', 'json',
-                '--all-namespaces',
-                '-l', label,
-                'daemonset,deployment,statefulset'
-            ]
-            output = check_output(cmd).decode('UTF-8')
-            deployments += json.loads(output)['items']
+        cmd = [
+            'kubectl', 'get',
+            '-o', 'json',
+            '--all-namespaces',
+            '-l', 'cdk-restart-on-ca-change=true',
+            'daemonset,deployment,statefulset'
+        ]
+        output = check_output(cmd).decode('UTF-8')
+        deployments = json.loads(output)['items']
 
         # Get ServiceAccounts
         service_account_names = set(

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -927,15 +927,6 @@ def update_certificates():
     clear_flag('config.changed.extra_sans')
 
 
-@when('kubernetes-master.components.started',
-      'tls_client.certs.changed')
-def kick_api_server():
-    # certificate changed, so restart the api server
-    hookenv.log("Certificate information changed, restarting api server")
-    service_restart('snap.kube-apiserver.daemon')
-    clear_flag('tls_client.certs.changed')
-
-
 @when_any('kubernetes-master.components.started',
           'kubernetes-master.ceph.configured',
           'keystone-credentials.available.auth')


### PR DESCRIPTION
If the certificates or CA info is updated (re-issued, transferred to a different CA, etc), the charm needs to handle that by updating the files on disk (already done) and restarting the services (added here).