### PR TITLE
Adding iptables fix for issue with kube-proxy

### DIFF
--- a/templates/kube-proxy-iptables-fix.sh
+++ b/templates/kube-proxy-iptables-fix.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# add the chain, note that adding twice is ok as it will just error.
+/sbin/iptables -t nat -N KUBE-MARK-DROP
+
+# need to check the creation of the rule to ensure we only create it once.
+if ! /sbin/iptables -t nat -C KUBE-MARK-DROP -j MARK --set-xmark 0x8000/0x8000 &> /dev/null; then
+  /sbin/iptables -t nat -A KUBE-MARK-DROP -j MARK --set-xmark 0x8000/0x8000
+fi

--- a/templates/service-iptables-fix.service
+++ b/templates/service-iptables-fix.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Apply iptables rule for KUBE-MARK-DROP
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/kube-proxy-iptables-fix.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
kube-proxy requries an iptables chain created by kubelet.

This is intended to be a stop-gap until we can do the necessary work to run kubelet on the masters.