### PR TITLE
revert data_changed guard on create_kubeconfig

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1512,19 +1512,8 @@ def build_kubeconfig(server):
 
         # Create an absolute path for the kubeconfig file.
         kubeconfig_path = os.path.join(os.sep, 'home', 'ubuntu', 'config')
+
         # Create the kubeconfig on this system so users can access the cluster.
-
-        try:
-            with open(kubeconfig_path, 'r') as conf:
-                config_matrix = {
-                    'keystone': ks,
-                    'conf': conf.read()
-                }
-                if not data_changed('kube-config-build', config_matrix):
-                    return
-        except FileNotFoundError:
-            pass
-
         hookenv.log('Writing kubeconfig file.')
 
         if ks:


### PR DESCRIPTION
This partially reverts #33.  @joedborg hit an issue where the k8s master would write kubeconfig before the kubeapi-load-balancer joined.  This caused `server: $master:6443` to be written to the config file. Since we weren't checking for `server` in data_changed's `config_matrix`, we never re-wrote an accurate config that included the load balancer's ip.

`server` isn't the only problem -- we would have also missed any changes to `ca_crt` and `client_pass` because the `conf.read()` happens *before* any of these changed values get written, which would make data_changed False and cause us to return early.

For now, we'll keep the part of #33 that logs the write to disk (versus a more expensive `status_set` on every hook).

To fully fix the spirit of https://bugs.launchpad.net/charm-kubernetes-master/+bug/1822021, we'll need to implement a helper that can compare what's on disk to what *would* be written to disk, and write a new config when the 2 differ.