### PR TITLE
Controller manager on secured port

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1805,7 +1805,10 @@ def configure_controller_manager():
     controller_opts['v'] = '2'
     controller_opts['root-ca-file'] = str(ca_crt_path)
     controller_opts['logtostderr'] = 'true'
-    controller_opts['master'] = 'http://127.0.0.1:8080'
+    controller_opts['kubeconfig'] = kubecontrollermanagerconfig_path
+    controller_opts['authorization-kubeconfig'] = kubecontrollermanagerconfig_path
+    controller_opts['authentication-kubeconfig'] = kubecontrollermanagerconfig_path
+    controller_opts['use-service-account-credentials'] = 'true'
     controller_opts['service-account-private-key-file'] = \
         '/root/cdk/serviceaccount.key'
     controller_opts['tls-cert-file'] = str(server_crt_path)

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -237,6 +237,12 @@ def add_rbac_roles():
                                                      'kube-proxy')
                     ftokens.write(towrite)
                     continue
+                if record[2] == 'kube_controller_manager':
+                    towrite = '{0},{1},{2}\n'.format(record[0],
+                                                     'system:kube-controller-manager',
+                                                     'kube-controller-manager')
+                    ftokens.write(towrite)
+                    continue
                 if record[2] == 'kubelet' and record[1] == 'kubelet':
                     continue
 

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1558,7 +1558,7 @@ def build_kubeconfig(server):
                          'kube-controller-manager')
             controller_manager_token = \
                           get_token('system:kube-controller-manager')
-        address = hookenv.unit_get('public-address')
+        address = get_ingress_address('kube-api-endpoint')
         server = 'https://{0}:{1}'.format(address, 6443)
         create_kubeconfig(kubecontrollermanagerconfig_path,
                           server, ca_crt_path,

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -107,6 +107,7 @@ db = unitdata.kv()
 checksum_prefix = 'kubernetes-master.resource-checksums.'
 configure_prefix = 'kubernetes-master.prev_args.'
 keystone_root = '/root/cdk/keystone'
+kubecontrollermanagerconfig_path = '/root/cdk/kubecontrollermanagerconfig'
 
 register_trigger(when='endpoint.aws.ready',  # when set
                  set_flag='kubernetes-master.aws.changed')
@@ -1550,6 +1551,19 @@ def build_kubeconfig(server):
             proxy_token = get_token('system:kube-proxy')
         create_kubeconfig(kubeproxyconfig_path, server, ca_crt_path,
                           token=proxy_token, user='kube-proxy')
+
+        controller_manager_token = get_token('system:kube-controller-manager')
+        if not controller_manager_token:
+            setup_tokens(None, 'system:kube-controller-manager',
+                         'kube-controller-manager')
+            controller_manager_token = \
+                          get_token('system:kube-controller-manager')
+        address = hookenv.unit_get('public-address')
+        server = 'https://{0}:{1}'.format(address, 6443)
+        create_kubeconfig(kubecontrollermanagerconfig_path,
+                          server, ca_crt_path,
+                          token=controller_manager_token,
+                          user='kube-controller-manager')
 
 
 def get_dns_ip():


### PR DESCRIPTION
Hi,

**Motivation for this PR**:
At this moment controller managers services are talking to API server on the insecured port. (i.e:: auth and authz bypassed) PodSecurityPolicy need controller-manager service running, authentificated with it's own credential. Otherwise all PodSecurityPolicy objects would be allowed for each Pod created by controller-manager (ReplicaSet, Deployment...)

I have a fork of this charm with this change since more than 6 months and I'm interested to push it upstream.

Thanks,

PS: for the variable "kubecontrollermanagerconfig_path" maybe it's better to have it in kubernetes_common layer. If this PR is accepted I will create another PR in kubernetes_common to put this variable in the right place by refering this PR