### PR TITLE
Fix k8s 1.16 kube-proxy failing to get Node IP

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -729,8 +729,12 @@ def start_master():
     # kube-proxy
     cni = endpoint_from_flag('cni.available')
     cluster_cidr = cni.get_config()['cidr']
+    # Set bind address to work around node IP error when there's no kubelet
+    # https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841114
+    bind_address = get_ingress_address('kube-control')
     configure_kube_proxy(configure_prefix,
-                         ['127.0.0.1:8080'], cluster_cidr)
+                         ['127.0.0.1:8080'], cluster_cidr,
+                         bind_address=bind_address)
     service_restart('snap.kube-proxy.daemon')
 
     set_state('kubernetes-master.components.started')


### PR DESCRIPTION
Depends on https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/7

Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841114

Configuring kube-proxy with --bind-address prevents it from trying to look up the Node IP for a Node that doesn't exist.