### PR TITLE
Revert enabling non-OpenStack cloud provider settings in cdk-addons

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1024,9 +1024,11 @@ def configure_cdk_addons():
         else:
             dashboard_auth = 'basic'
 
-    enable_aws = str(is_flag_set('endpoint.aws.ready')).lower()
-    enable_azure = str(is_flag_set('endpoint.azure.ready')).lower()
-    enable_gcp = str(is_flag_set('endpoint.gcp.ready')).lower()
+    # clouds are not enabled in cdk-addons until we support the relevant
+    # external cloud provider
+    enable_aws = 'false'
+    enable_azure = 'false'
+    enable_gcp = 'false'
     enable_openstack = str(is_flag_set('endpoint.openstack.ready')).lower()
     openstack = endpoint_from_flag('endpoint.openstack.ready')
 


### PR DESCRIPTION
Until we support the other external cloud providers, it's safer to leave the flags set to False.  This means the storage class won't be automatically created, but it also means that the transition to the external cloud provider will be seamless when the time comes.