### PR TITLE
Remove direct call to reconfigure

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2635,9 +2635,7 @@ def enable_aws_iam_webhook():
     # when we start the api server.
     if is_flag_set('etcd.available'):
         # call the other things we need to update
-        etcd = endpoint_from_flag('etcd.available')
-
-        configure_apiserver(etcd.get_connection_string())
+        clear_flag('kubernetes-master.apiserver.configured')
         build_kubeconfig()
     set_flag('kubernetes-master.aws-iam.configured')
 


### PR DESCRIPTION
The preferred method is now via flag removal. Removing api server config flag to force a reconfigure. Note that the timing of this isn’t critical, so I am not concerned about synchronous call vs asynchronous.