### PR TITLE
Update admission plugin handling

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1659,12 +1659,13 @@ def configure_apiserver():
     api_opts['etcd-servers'] = etcd_connection_string
 
     # Many admission plugins are enabled by default as of 1.10.
-    # See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options
+    # Source: https://bit.ly/2meP9XT
     #
     # Current enabled-by-default plugins are:
-    # NamespaceLifecycle, LimitRanger, ServiceAccount, TaintNodesByCondition, Priority,
-    # DefaultTolerationSeconds, DefaultStorageClass, PersistentVolumeClaimResize,
-    # MutatingAdmissionWebhook, ValidatingAdmissionWebhook, ResourceQuota
+    # NamespaceLifecycle, LimitRanger, ServiceAccount, TaintNodesByCondition,
+    # Priority, DefaultTolerationSeconds, DefaultStorageClass,
+    # PersistentVolumeClaimResize, MutatingAdmissionWebhook,
+    # ValidatingAdmissionWebhook, ResourceQuota
     #
     # The list below need only include the plugins we want to enable
     # in addition to the defaults.

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1659,7 +1659,7 @@ def configure_apiserver():
     api_opts['etcd-servers'] = etcd_connection_string
 
     # In Kubernetes 1.10 and later, some admission plugins are enabled by
-    # default. The current list of default plugins can be found at 
+    # default. The current list of default plugins can be found at
     # https://bit.ly/2meP9XT, listed under the '--enable-admission-plugins'
     # option.
     #

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1658,29 +1658,24 @@ def configure_apiserver():
     api_opts['etcd-certfile'] = etcd_cert
     api_opts['etcd-servers'] = etcd_connection_string
 
-    admission_control_pre_1_9 = [
-        'NamespaceLifecycle',
-        'LimitRanger',
-        'ServiceAccount',
-        'ResourceQuota',
-        'DefaultTolerationSeconds'
-    ]
+    # Many admission plugins are enabled by default as of 1.10.
+    # See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options
+    #
+    # Current enabled-by-default plugins are:
+    # NamespaceLifecycle, LimitRanger, ServiceAccount, TaintNodesByCondition, Priority,
+    # DefaultTolerationSeconds, DefaultStorageClass, PersistentVolumeClaimResize,
+    # MutatingAdmissionWebhook, ValidatingAdmissionWebhook, ResourceQuota
+    #
+    # The list below need only include the plugins we want to enable
+    # in addition to the defaults.
 
-    admission_control = [
-        'NamespaceLifecycle',
-        'LimitRanger',
-        'ServiceAccount',
+    admission_plugins = [
         'PersistentVolumeLabel',
-        'DefaultStorageClass',
-        'DefaultTolerationSeconds',
-        'MutatingAdmissionWebhook',
-        'ValidatingAdmissionWebhook',
-        'ResourceQuota'
     ]
 
     auth_mode = hookenv.config('authorization-mode')
     if 'Node' in auth_mode:
-        admission_control.append('NodeRestriction')
+        admission_plugins.append('NodeRestriction')
 
     ks = endpoint_from_flag('keystone-credentials.available.auth')
     aws = endpoint_from_flag('endpoint.aws-iam.ready')
@@ -1736,15 +1731,9 @@ def configure_apiserver():
             remove_state('keystone.apiserver.configured')
 
     api_opts['authorization-mode'] = auth_mode
+    api_opts['enable-admission-plugins'] = ','.join(admission_plugins)
 
     kube_version = get_version('kube-apiserver')
-    if kube_version < (1, 6):
-        hookenv.log('Removing DefaultTolerationSeconds from admission-control')
-        admission_control_pre_1_9.remove('DefaultTolerationSeconds')
-    if kube_version < (1, 9):
-        api_opts['admission-control'] = ','.join(admission_control_pre_1_9)
-    else:
-        api_opts['admission-control'] = ','.join(admission_control)
 
     if kube_version > (1, 6) and \
        hookenv.config('enable-metrics'):

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1658,9 +1658,10 @@ def configure_apiserver():
     api_opts['etcd-certfile'] = etcd_cert
     api_opts['etcd-servers'] = etcd_connection_string
 
-    # As of Kubernetes 1.10, many admission plugins are enabled by default.
-    # The default plugins can be found at https://bit.ly/2meP9XT, listed
-    # under the '--enable-admission-plugins' option.
+    # In Kubernetes 1.10 and later, some admission plugins are enabled by
+    # default. The current list of default plugins can be found at 
+    # https://bit.ly/2meP9XT, listed under the '--enable-admission-plugins'
+    # option.
     #
     # The list below need only include the plugins we want to enable
     # in addition to the defaults.

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1658,14 +1658,9 @@ def configure_apiserver():
     api_opts['etcd-certfile'] = etcd_cert
     api_opts['etcd-servers'] = etcd_connection_string
 
-    # Many admission plugins are enabled by default as of 1.10.
-    # Source: https://bit.ly/2meP9XT
-    #
-    # Current enabled-by-default plugins are:
-    # NamespaceLifecycle, LimitRanger, ServiceAccount, TaintNodesByCondition,
-    # Priority, DefaultTolerationSeconds, DefaultStorageClass,
-    # PersistentVolumeClaimResize, MutatingAdmissionWebhook,
-    # ValidatingAdmissionWebhook, ResourceQuota
+    # As of Kubernetes 1.10, many admission plugins are enabled by default.
+    # The default plugins can be found at https://bit.ly/2meP9XT, listed
+    # under the '--enable-admission-plugins' option.
     #
     # The list below need only include the plugins we want to enable
     # in addition to the defaults.


### PR DESCRIPTION
As of 1.10, --admission-control is deprecated in favor of
--enable-admission-plugins, and many plugins are enable by default.
Source
(https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use).

This change removes --admission-control and replaces it with
--enable-admission-plugins. It also drops support for admission plugin
handling of versions prior to 1.10.

Tested by upgrading a running kubernetes-master to a build with these changes, then doing:
`juju run -u kubernetes-master/0 -- snap get kube-apiserver args`. Confirmed that:
1. The `--admission-control` arg was gone.
2. There was a `--enable-admission-plugins="PersistentVolumeLabel"` arg
3. All services and pods were running.

Also tested:
`juju config kubernetes-master api-extra-args="enable-admission-plugins=PersistentVolumeLabel,PodSecurityPolicy"` and confirmed that `PodSecurityPolicy` was added to the `--enable-admission-plugins` arg on the kube-apiserver snap.

Fixes: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841416