### PR TITLE
Report in status if Vault encryption is expected but not ready

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -581,6 +581,13 @@ def set_final_status():
         hookenv.status_set('blocked', msg)
         return
 
+    vault_kv_related = 'vault-kv' in goal_state.get('relations', {})
+    vault_kv_ready = is_state('layer.vault-kv.ready')
+    if vault_kv_related and not vault_kv_ready:
+        hookenv.status_set('waiting', 'Waiting for encryption info from Vault '
+                                      'to secure secrets')
+        return
+
     if is_state('kubernetes-master.components.started'):
         # All services should be up and running at this point. Double-check...
         failing_services = master_services_down()


### PR DESCRIPTION
Due to [lp:1843809](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1843809) we hit an issue where Vault was related for secrets encryption but never provided the config needed to actually do the encryption. However, this was never indicated in any way which would lead the admin to expect that the secrets would be encrypted at rest when they would not in fact be.