### PR TITLE
hacluster depends on the apiserver

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2378,7 +2378,7 @@ def haconfig_changed():
     clear_flag('hacluster-configured')
 
 
-@when('ha.connected')
+@when('ha.connected', 'kubernetes-master.components.started')
 @when_not('hacluster-configured')
 def configure_hacluster():
     for service in master_services:


### PR DESCRIPTION
Adding a dependency on the API server being up before attempting to setup hacluster.

Tested with k8s 1.15 from master as a base install and also installed 1.15/stable CK with hacluster and saw the issue and then upgraded to my built charm and saw things correct themselves.

Doesn't fix, but related: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841005