### PR TITLE
Remove broken legacy-handling of client-ca-file apiserver arg

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1634,13 +1634,6 @@ def configure_apiserver():
         return
 
     api_opts = {}
-    # at one point in time, this code would set ca-client-cert,
-    # but this was removed. This was before configure_kubernetes_service
-    # kept track of old arguments and removed them, so client-ca-cert
-    # was able to hang around forever stored in the snap configuration.
-    # This removes that stale configuration from the snap if it still
-    # exists.
-    api_opts['client-ca-file'] = 'null'
 
     if is_privileged():
         api_opts['allow-privileged'] = 'true'
@@ -1704,7 +1697,6 @@ def configure_apiserver():
     if ks and aws:
         hookenv.log('unable to have BOTH Keystone and '
                     'AWS IAM webhook auth at the same time!')
-
     elif aws:
         api_opts['authentication-token-webhook-config-file'] = aws_iam_webhook
     elif ks:


### PR DESCRIPTION
Once upon a time this code worked properly, because each api-server arg
was passed to 'snap set' separately, and args that had a value of 'null'
would be unset, and therefore not passed as an arg when the api-server
was started.

Since then, we've changed the snap such that all args to the api-server
are passed to the snap via a single 'snap set args="..."'. Instead of
causing an arg to be unset, a value of 'null' will now be passed through
to the api-server, which in this case, causes the api-server to fail to
start.

Removing client-ca-file from api_opts when it's not needed fixes the
problem. If it's not there, it won't be passed as an arg to the
api-server.

Fixes: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1845962

See related (new) tests at: https://github.com/charmed-kubernetes/jenkins/pull/520