### PR TITLE
Adding nagios plugin to monitor the API server.

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1294,9 +1294,9 @@ def ceph_storage():
 
 @when('nrpe-external-master.available')
 @when_not('nrpe-external-master.initial-config')
-def initial_nrpe_config(nagios=None):
+def initial_nrpe_config():
     set_state('nrpe-external-master.initial-config')
-    update_nrpe_config(nagios)
+    update_nrpe_config()
 
 
 @when('config.changed.authorization-mode')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -88,7 +88,8 @@ from charms.layer.kubernetes_common import client_crt_path
 from charms.layer.kubernetes_common import client_key_path
 from charms.layer.kubernetes_common import kubectl
 
-from charms.layer.nagios import install_nagios_plugin, remove_nagios_plugin
+from charms.layer.nagios import install_nagios_plugin_from_file
+from charms.layer.nagios import remove_nagios_plugin
 
 
 # Override the default nagios shortname regex to allow periods, which we
@@ -1369,15 +1370,15 @@ def remove_rbac_resources():
 def update_nrpe_config():
     services = ['snap.{}.daemon'.format(s) for s in master_services]
 
-    plugin_path = install_nagios_plugin('templates/nagios_plugin.py',
-                                        'check_k8s_master.py')
+    plugin = install_nagios_plugin_from_file('templates/nagios_plugin.py',
+                                             'check_k8s_master.py')
     hostname = nrpe.get_nagios_hostname()
     current_unit = nrpe.get_nagios_unit_name()
     nrpe_setup = nrpe.NRPE(hostname=hostname)
     nrpe.add_init_service_checks(nrpe_setup, services, current_unit)
     nrpe_setup.add_check('k8s-api-server',
                          'Verify that the Kubernetes API server is accessible',
-                         plugin_path)
+                         str(plugin))
     nrpe_setup.write()
 
 

--- a/templates/nagios_plugin.py
+++ b/templates/nagios_plugin.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2019 Canonical Ltd.
+
+import nagios_plugin3
+import socket
+from subprocess import check_output
+
+snap_resources = ['kubectl', 'kube-apiserver', 'kube-controller-manager',
+                  'kube-scheduler', 'cdk-addons', 'kube-proxy']
+
+
+def check_snaps_installed():
+    """Confirm the snaps are installed, raise an error if not"""
+    for snap_name in snap_resources:
+        cmd = ['snap', 'list', snap_name]
+        try:
+            check_output(cmd).decode('UTF-8')
+        except Exception:
+            msg = '{} snap is not installed'.format(snap_name)
+            raise nagios_plugin3.CriticalError(msg)
+
+
+def test_connection(host, port):
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(1)
+        s.connect((host, int(port)))
+        s.shutdown(socket.SHUT_RDWR)
+    finally:
+        s.close()
+
+
+def verify_local_connection_to_apiserver():
+    try:
+        test_connection('localhost', 8080)
+    except Exception:
+        raise nagios_plugin3.CriticalError("Unable to reach "
+                                           "API server on local port")
+
+
+def verify_remote_connection_to_apiserver():
+    try:
+        test_connection(socket.gethostbyname(socket.gethostname()), 6443)
+    except Exception:
+        raise nagios_plugin3.CriticalError("Unable to reach "
+                                           "API server on remote port")
+
+
+def main():
+    nagios_plugin3.try_check(check_snaps_installed)
+    nagios_plugin3.try_check(verify_local_connection_to_apiserver)
+    nagios_plugin3.try_check(verify_remote_connection_to_apiserver)
+    print("OK - API server is up and accessible")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/nagios_plugin.py
+++ b/templates/nagios_plugin.py
@@ -31,14 +31,6 @@ def test_connection(host, port):
         s.close()
 
 
-def verify_local_connection_to_apiserver():
-    try:
-        test_connection('localhost', 8080)
-    except Exception:
-        raise nagios_plugin3.CriticalError("Unable to reach "
-                                           "API server on local port")
-
-
 def verify_remote_connection_to_apiserver():
     try:
         test_connection(socket.gethostbyname(socket.gethostname()), 6443)
@@ -49,7 +41,6 @@ def verify_remote_connection_to_apiserver():
 
 def main():
     nagios_plugin3.try_check(check_snaps_installed)
-    nagios_plugin3.try_check(verify_local_connection_to_apiserver)
     nagios_plugin3.try_check(verify_remote_connection_to_apiserver)
     print("OK - API server is up and accessible")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,5 +18,6 @@ layer = MagicMock()
 sys.modules['charms.layer'] = layer
 sys.modules['charms.layer.hacluster'] = layer.hacluster
 sys.modules['charms.layer.kubernetes_common'] = layer.kubernetes_common
+sys.modules['charms.layer.nagios'] = layer.nagios
 
 os.environ['JUJU_MODEL_UUID'] = 'test-1234'


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1844549 and https://bugs.launchpad.net/charm-kubernetes-master/+bug/1844547

This plugin verifies the API server is reachable on the localhost and the external IP. It also verifies the snaps are installed.

Nagios reports on crash-looping services as tested by adding invalid command-line options for the API server and the controller manager. Both resulted in errors reported by nagios.

This change depends on a nagios-layer change and can not be merged before that is merged: https://github.com/charmed-kubernetes/layer-nagios/pull/1