### PR TITLE
Handle upgrades for sending new cluster-name to cdk-addons

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -48,6 +48,16 @@ namespace-delete:
     - name
 upgrade:
     description: Upgrade the kubernetes snaps
+    params:
+      fix-cluster-name:
+        type: boolean
+        default: true
+        description: >-
+          If using the OpenStack cloud provider, whether to fix the cluster
+          name sent to it to include the cluster tag. This fixes an issue
+          with load balancers conflicting with other clusters in the same
+          project but will cause new load balancers to be created which will
+          require manual intervention to resolve.
 get-kubeconfig:
   description: Retrieve Kubernetes cluster config, including credentials
 apply-manifest:

--- a/actions/upgrade
+++ b/actions/upgrade
@@ -2,7 +2,7 @@
 set -eux
 
 if [[ "$(action-get fix-cluster-name)" == "true" ]]; then
-    charms.reactive set_state 'kubernetes-master.cdk-addons.unique-cluster-name'
+    charms.reactive set_state 'kubernetes-master.cdk-addons.unique-cluster-tag'
 fi
 
 charms.reactive set_state kubernetes-master.upgrade-specified

--- a/actions/upgrade
+++ b/actions/upgrade
@@ -2,8 +2,7 @@
 set -eux
 
 if [[ "$(action-get fix-cluster-name)" == "true" ]]; then
-    charms.reactive set_state kubernetes-master.cluster-name.new
-    charms.reactive remove_state kubernetes-master.cluster-name.legacy
+    charms.reactive set_state 'kubernetes-master.cdk-addons.unique-cluster-name'
 fi
 
 charms.reactive set_state kubernetes-master.upgrade-specified

--- a/actions/upgrade
+++ b/actions/upgrade
@@ -1,5 +1,10 @@
 #!/bin/sh
 set -eux
 
+if [[ "$(action-get fix-cluster-name)" == "true" ]]; then
+    charms.reactive set_state kubernetes-master.cluster-name.new
+    charms.reactive remove_state kubernetes-master.cluster-name.legacy
+fi
+
 charms.reactive set_state kubernetes-master.upgrade-specified
 exec hooks/config-changed

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -180,10 +180,26 @@ def maybe_install_kube_proxy():
         calculate_and_store_resource_checksums(checksum_prefix, snap_resources)
 
 
+@when_not('kubernetes-master.first-init.ran')
+def first_init():
+    # Do anything that we want to only do once.
+    if not is_state('kubernetes-master.cluster-name.legacy'):
+        # For new installs, this will run before check_for_upgrade_needed,
+        # but for upgrades from older code, that will run first.
+        set_state('kubernetes-master.cluster-name.new')
+    set_state('kubernetes-master.first-init.ran')
+
+
 @hook('upgrade-charm')
 def check_for_upgrade_needed():
     '''An upgrade charm event was triggered by Juju, react to that here.'''
     hookenv.status_set('maintenance', 'Checking resources')
+
+    # Handle upgrade path for cluster name being sent to cdk-addons.
+    if not is_state('kubernetes-master.cluster-name.new'):
+        # For new installs, first_init will run before this, but for
+        # upgrades from older code, this will run first.
+        set_state('kubernetes-master.cluster-name.legacy')
 
     # migrate to new flags
     if is_state('kubernetes-master.restarted-for-cloud'):
@@ -1084,6 +1100,10 @@ def configure_cdk_addons():
     enable_gcp = 'false'
     enable_openstack = str(is_flag_set('endpoint.openstack.ready')).lower()
     openstack = endpoint_from_flag('endpoint.openstack.ready')
+    if is_state('kubernetes-master.cluster-name.new'):
+        cluster_name = leader_get('cluster_tag')
+    elif is_state('kubernetes-master.cluster-name.legacy'):
+        cluster_name = 'kubernetes'
 
     args = [
         'arch=' + arch(),
@@ -1109,7 +1129,7 @@ def configure_cdk_addons():
         'enable-gcp=' + enable_gcp,
         'enable-openstack=' + enable_openstack,
         'monitorstorage=' + hookenv.config('monitoring-storage'),
-        'cluster-tag='+leader_get('cluster_tag'),
+        'cluster-tag='+cluster_name,
     ]
     if openstack:
         args.extend([

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -182,8 +182,8 @@ def maybe_install_kube_proxy():
 
 @hook('install')
 def fresh_install():
-    # fresh installs should always send the unique cluster name to cdk-addons
-    set_state('kubernetes-master.cdk-addons.unique-cluster-name')
+    # fresh installs should always send the unique cluster tag to cdk-addons
+    set_state('kubernetes-master.cdk-addons.unique-cluster-tag')
 
 
 @hook('upgrade-charm')
@@ -1091,11 +1091,11 @@ def configure_cdk_addons():
     enable_openstack = str(is_flag_set('endpoint.openstack.ready')).lower()
     openstack = endpoint_from_flag('endpoint.openstack.ready')
 
-    if is_state('kubernetes-master.cdk-addons.unique-cluster-name'):
+    if is_state('kubernetes-master.cdk-addons.unique-cluster-tag'):
         cluster_tag = leader_get('cluster_tag')
     else:
         # allow for older upgraded charms to control when they start sending
-        # the unique cluster name to cdk-addons
+        # the unique cluster tag to cdk-addons
         cluster_tag = 'kubernetes'
 
     args = [


### PR DESCRIPTION
This fixes the issue where upgrading the charm code will cause the OpenStack cloud provider to use a new `cluster-name` value and thus recreate all load balancers with new names, requiring manual intervention. This makes it so the operator needs to invoke the upgrade action to enable the new cluster name and can explicitly prevent the switch by overriding the `fix-cluster-name` action param.

Fixes [lp:1850539](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1850539)