### PR TITLE
Adding templates necessary to support kube-state-metrics

### DIFF
--- a/templates/prometheus/kube-state-metrics.yaml.j2
+++ b/templates/prometheus/kube-state-metrics.yaml.j2
@@ -1,0 +1,10 @@
+job_name: 'kube-state-metrics'
+scrape_interval: 30s
+scheme: https
+tls_config:
+  ca_file: __placeholder__
+bearer_token: {{k8s_token}}
+metrics_path: /api/v1/namespaces/kube-system/services/kube-state-metrics:8080/proxy/metrics
+static_configs:
+  - targets:
+    - {{k8s_api_address}}:{{k8s_api_port}}

--- a/templates/prometheus/kube-state-telemetry.yaml.j2
+++ b/templates/prometheus/kube-state-telemetry.yaml.j2
@@ -1,0 +1,10 @@
+job_name: 'kube-state-telemetry'
+scrape_interval: 30s
+scheme: https
+tls_config:
+  ca_file: __placeholder__
+bearer_token: {{k8s_token}}
+metrics_path: /api/v1/namespaces/kube-system/services/kube-state-metrics:8081/proxy/metrics
+static_configs:
+  - targets:
+    - {{k8s_api_address}}:{{k8s_api_port}}


### PR DESCRIPTION
Part of the fix for https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1850710

This provides scrape jobs for prometheus to scrape kube-state-metrics endpoints.

Tested by deploying to AWS with https://github.com/charmed-kubernetes/cdk-addons/pull/156 and verifying I could create graphs with kube-state-metrics data.