### PR TITLE
adding default storage classes for clouds

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1193,11 +1193,9 @@ def configure_cdk_addons():
         else:
             dashboard_auth = 'basic'
 
-    # clouds are not enabled in cdk-addons until we support the relevant
-    # external cloud provider
-    enable_aws = 'false'
-    enable_azure = 'false'
-    enable_gcp = 'false'
+    enable_aws = str(is_flag_set('endpoint.aws.ready')).lower()
+    enable_azure = str(is_flag_set('endpoint.azure.ready')).lower()
+    enable_gcp = str(is_flag_set('endpoint.gcp.ready')).lower()
     enable_openstack = str(is_flag_set('endpoint.openstack.ready')).lower()
     openstack = endpoint_from_flag('endpoint.openstack.ready')
 


### PR DESCRIPTION
These storage classes were removed by @johnsca shortly after adding them, but we have had requests to add them. The concern was that we should hold off until these were using the external providers, but some external providers don't seem to be shaping up and there are upgrade stories for transitioning from internal to external so the decision was made to enable these again for convenience.

Fixes: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1815967

Tested on AWS, GCP, and Azure by deploying and helm deploying a workload that creates a PVC and verifying both that the backing PV was created and that the workload was operating correctly.

Depends on https://github.com/juju-solutions/charm-azure-integrator/pull/21