### PR TITLE
Add support for CephFS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -183,7 +183,7 @@ options:
     default: "auto"
     description: |
       The storage class to make the default storage class. Allowed values are "auto",
-      "none", "ceph-xfs", "ceph-ext4". Note: Only works in Kubernetes >= 1.10
+      "none", "ceph-xfs", "ceph-ext4", "cephfs". Note: Only works in Kubernetes >= 1.10
   keystone-policy:
     default: |
       apiVersion: v1

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -1,11 +1,12 @@
 import json
 from pathlib import Path
-from subprocess import check_call, check_output
+from subprocess import check_output
 from tempfile import TemporaryDirectory
 
 from charmhelpers.core import hookenv
 from charms.reactive import endpoint_from_flag, is_flag_set, set_flag
 
+from charms.layer import basic
 from charms.layer import kubernetes_common
 
 
@@ -73,7 +74,7 @@ def get_api_endpoint(relation=None):
 
 def query_cephfs_enabled(ceph_ep):
     if not is_flag_set('kubernetes-master.ceph-cli.installed'):
-        check_call(['apt', 'install', '-y', 'ceph-common'])
+        basic.apt_install(['ceph-common'])
         set_flag('kubernetes-master.ceph-cli.installed')
     ceph_config = {
         'hosts': ceph_ep.mon_hosts(),

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1181,8 +1181,11 @@ def configure_cdk_addons():
         ceph['kubernetes_key'] = b64_ceph_key.decode('ascii')
         ceph['mon_hosts'] = ceph_ep.mon_hosts()
         default_storage = hookenv.config('default-storage')
+        cephFsEnabled = kubernetes_master.query_cephfs_enabled(ceph_ep)
+        cephFsEnabled = str(cephFsEnabled).lower()
     else:
         cephEnabled = "false"
+        cephFsEnabled = "false"
 
     keystone = {}
     ks = endpoint_from_flag('keystone-credentials.available.auth')
@@ -1226,6 +1229,7 @@ def configure_cdk_addons():
         'enable-metrics=' + metricsEnabled,
         'enable-gpu=' + str(gpuEnable).lower(),
         'enable-ceph=' + cephEnabled,
+        'enable-cephfs='+cephFsEnabled,
         'ceph-admin-key=' + (ceph.get('admin_key', '')),
         'ceph-kubernetes-key=' + (ceph.get('admin_key', '')),
         'ceph-mon-hosts="' + (ceph.get('mon_hosts', '')) + '"',


### PR DESCRIPTION
Adds detecting of CephFS when Ceph is related and, if present, informs cdk-addons to enable the cephfs-csi plugin.

Part of https://bugs.launchpad.net/charm-kubernetes-master/+bug/1862217