### PR TITLE
Allow for errors from ceph CLI

### DIFF
--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 from tempfile import TemporaryDirectory
 
 from charmhelpers.core import hookenv
@@ -90,5 +90,10 @@ def query_cephfs_enabled(ceph_ep):
             'auth cluster required = {auth}\n'
             'auth service required = {auth}\n'
             'auth client required = {auth}\n'.format(**ceph_config))
-        out = check_output(['ceph', 'mds', 'versions', '-c', str(conf_file)])
-    return bool(json.loads(out))
+        try:
+            out = check_output(['ceph', 'mds', 'versions',
+                                '-c', str(conf_file)])
+            return bool(json.loads(out))
+        except CalledProcessError:
+            hookenv.log('Unable to determine if CephFS is enabled', 'ERROR')
+            return False


### PR DESCRIPTION
If k8s-master is deployed on pre-19.10 without a cloud:train added to the install_sources config, the check for CephFS will fail and cause errors even if CephFS is not being used.  This resolves that by catching the error and defaulting to not detecting CephFS.