### PR TITLE
Add default-cni config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install tox-travis
 script:

--- a/config.yaml
+++ b/config.yaml
@@ -307,3 +307,15 @@ options:
         emptyDir: {}
       grafana:
         emptyDir: {}
+  default-cni:
+    type: string
+    description: |
+      Default CNI network to use when multiple CNI subordinates are related.
+
+      The value of this config should be the application name of a related CNI
+      subordinate. For example:
+
+      juju config kubernetes-master default-cni=flannel
+
+      If unspecified, then the default CNI network is chosen alphabetically.
+    default: ""

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2863,6 +2863,9 @@ def api_server_stopped():
 
 @when('kube-control.connected')
 def send_default_cni():
+    ''' Send the value of the default-cni config to the kube-control relation.
+    This allows kubernetes-worker to use the same config value as well.
+    '''
     default_cni = hookenv.config('default-cni')
     kube_control = endpoint_from_flag('kube-control.connected')
     kube_control.set_default_cni(default_cni)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@ import os
 import sys
 from unittest.mock import MagicMock
 
+
+def identity(x):
+    return x
+
+
 # mock dependencies which we don't care about covering in our tests
 ch = MagicMock()
 sys.modules['charmhelpers'] = ch
@@ -12,8 +17,18 @@ sys.modules['charmhelpers.core.host'] = ch.core.host
 sys.modules['charmhelpers.core.templating'] = ch.core.templating
 sys.modules['charmhelpers.contrib'] = ch.contrib
 sys.modules['charmhelpers.contrib.charmsupport'] = ch.contrib.charmsupport
-sys.modules['charms.reactive'] = MagicMock()
-sys.modules['charms.leadership'] = MagicMock()
+
+reactive = MagicMock()
+sys.modules['charms.reactive'] = reactive
+reactive.when.return_value = identity
+reactive.when_any.return_value = identity
+reactive.when_not.return_value = identity
+reactive.when_none.return_value = identity
+reactive.hook.return_value = identity
+
+leadership = MagicMock()
+sys.modules['charms.leadership'] = leadership
+
 charms = MagicMock()
 sys.modules['charms'] = charms
 sys.modules['charms.coordinator'] = charms.coordinator

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -1,5 +1,8 @@
 import pytest
 from unittest import mock
+from reactive import kubernetes_master
+from charms.reactive import endpoint_from_flag, remove_state
+from charmhelpers.core import hookenv
 
 
 def patch_fixture(patch_target):
@@ -10,9 +13,15 @@ def patch_fixture(patch_target):
     return _fixture
 
 
-def test_imports():
-    # dummy test to just make sure files import properly
-    # replace with real tests later
-    from charms.layer import kubernetes_master as lib
-    from reactive import kubernetes_master as handlers
-    assert lib and handlers
+def test_send_default_cni():
+    hookenv.config.return_value = 'test-default-cni'
+    kubernetes_master.send_default_cni()
+    kube_control = endpoint_from_flag('kube-control.connected')
+    kube_control.set_default_cni.assert_called_once_with('test-default-cni')
+
+
+def test_default_cni_changed():
+    kubernetes_master.default_cni_changed()
+    remove_state.assert_called_once_with(
+        'kubernetes-master.components.started'
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = lint,py3
 
 [tox:travis]
 3.5: lint,py3
+3.6: lint,py3
+3.7: lint,py3
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/charm-kubernetes-master/+bug/1861709

Please be careful merging this, as it's mutually dependent on the work of other PRs in that issue. They will need to be merged together.

This adds the default-cni config to kubernetes-master. The default-cni value is used to select which of multiple cni configs from the cni relation to use. It is also sent via kube-control to kubernetes-worker.