### PR TITLE
Send fsName to cdk-addons for CephFS

### DIFF
--- a/actions/create-rbd-pv
+++ b/actions/create-rbd-pv
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from charms.reactive import is_state
-from charms.reactive import endpoint_from_flag
 from charmhelpers.fetch import apt_install
 from charmhelpers.core.templating import render
 from charmhelpers.core.hookenv import log
@@ -31,6 +30,8 @@ import json
 import re
 import os
 import sys
+
+from charms.layer.kubernetes_master import install_ceph_common
 
 
 os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
@@ -102,44 +103,6 @@ def main():
         cmd = ['kubectl', 'create', '-f', temp_template]
         debug_command(cmd)
         check_call(cmd)
-
-
-def install_ceph_common():
-    """Install ceph-common tools.
-
-    :return: None
-    """
-    ceph_admin = endpoint_from_flag('ceph-storage.available')
-
-    ceph_context = {
-        'mon_hosts': ceph_admin.mon_hosts(),
-        'fsid': ceph_admin.fsid(),
-        'auth_supported': ceph_admin.auth(),
-        'use_syslog': 'true',
-        'ceph_public_network': '',
-        'ceph_cluster_network': '',
-        'loglevel': 1,
-        'hostname': socket.gethostname(),
-    }
-    # Install the ceph common utilities.
-    apt_install(['ceph-common'], fatal=True)
-
-    etc_ceph_directory = '/etc/ceph'
-    if not os.path.isdir(etc_ceph_directory):
-        os.makedirs(etc_ceph_directory)
-    charm_ceph_conf = os.path.join(etc_ceph_directory, 'ceph.conf')
-    # Render the ceph configuration from the ceph conf template.
-    render('ceph.conf', charm_ceph_conf, ceph_context)
-
-    # The key can rotate independently of other ceph config, so validate it.
-    admin_key = os.path.join(
-        etc_ceph_directory, 'ceph.client.admin.keyring')
-    try:
-        with open(admin_key, 'w') as key_file:
-            key_file.write("[client.admin]\n\tkey = {}\n".format(
-                ceph_admin.key()))
-    except IOError as err:
-        log("IOError writing admin.keyring: {}".format(err))
 
 
 def get_version(bin_name):

--- a/actions/create-rbd-pv
+++ b/actions/create-rbd-pv
@@ -15,9 +15,7 @@
 # limitations under the License.
 
 from charms.reactive import is_state
-from charmhelpers.fetch import apt_install
 from charmhelpers.core.templating import render
-from charmhelpers.core.hookenv import log
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
 from charmhelpers.core.hookenv import action_fail
@@ -25,7 +23,6 @@ from subprocess import check_call
 from subprocess import check_output
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
-import socket
 import json
 import re
 import os
@@ -46,11 +43,11 @@ def main():
     """
     # k8s >= 1.10 uses CSI and doesn't directly create persistent volumes.
     if get_version('kube-apiserver') >= (1, 10):
-       print('This action is deprecated in favor of CSI creation of persistent volumes')
-       print('in Kubernetes >= 1.10. Just create the PVC and a PV will be created')
-       print('for you.')
-       action_fail('Deprecated, just create PVC.')
-       return
+        print('This action is deprecated in favor of CSI creation of')
+        print('persistent volumes in Kubernetes >= 1.10. Just create the PVC')
+        print('and a PV will be created for you.')
+        action_fail('Deprecated, just create PVC.')
+        return
 
     # validate relationship pre-reqs before additional steps can be taken.
     if not validate_relation():

--- a/actions/kubectl-actions.py
+++ b/actions/kubectl-actions.py
@@ -9,7 +9,6 @@ from charmhelpers.core.hookenv import (
     action_fail,
     action_name
 )
-from charmhelpers.core.templating import render
 
 
 def _kubectl(args):
@@ -51,7 +50,7 @@ def apply_manifest():
         manifest = json.loads(action_get("json"))
         with open(apply_path, "w") as manifest_file:
             json.dump(manifest, manifest_file)
-        output = _kubectl(["apply", "-f", apply_path,])
+        output = _kubectl(["apply", "-f", apply_path])
 
         action_set({
             "summary": "Manifest applied.",

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -3,7 +3,7 @@ import socket
 from pathlib import Path
 from subprocess import check_output, CalledProcessError
 
-from charmhelpers.core import hookenv, log
+from charmhelpers.core import hookenv
 from charmhelpers.core.templating import render
 from charmhelpers.fetch import apt_install
 from charms.reactive import endpoint_from_flag, is_flag_set
@@ -106,7 +106,7 @@ def install_ceph_common():
             key_file.write("[client.admin]\n\tkey = {}\n".format(
                 ceph_admin.key()))
     except IOError as err:
-        log("IOError writing admin.keyring: {}".format(err))
+        hookenv.log("IOError writing admin.keyring: {}".format(err))
 
 
 def query_cephfs_enabled():

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1188,7 +1188,6 @@ def configure_cdk_addons():
             ceph['fsname'] = kubernetes_master.get_cephfs_fsname()
         else:
             cephFsEnabled = "false"
-        cephFsEnabled = str(cephFsEnabled).lower()
     else:
         cephEnabled = "false"
         cephFsEnabled = "false"

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1183,7 +1183,7 @@ def configure_cdk_addons():
         ceph['kubernetes_key'] = b64_ceph_key.decode('ascii')
         ceph['mon_hosts'] = ceph_ep.mon_hosts()
         default_storage = hookenv.config('default-storage')
-        if kubernetes_master.query_cephfs_enabled(ceph_ep):
+        if kubernetes_master.query_cephfs_enabled():
             cephFsEnabled = "true"
             ceph['fsname'] = kubernetes_master.get_cephfs_fsname()
         else:

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1183,7 +1183,11 @@ def configure_cdk_addons():
         ceph['kubernetes_key'] = b64_ceph_key.decode('ascii')
         ceph['mon_hosts'] = ceph_ep.mon_hosts()
         default_storage = hookenv.config('default-storage')
-        cephFsEnabled = kubernetes_master.query_cephfs_enabled(ceph_ep)
+        if kubernetes_master.query_cephfs_enabled(ceph_ep):
+            cephFsEnabled = "true"
+            ceph['fsname'] = kubernetes_master.get_cephfs_fsname()
+        else:
+            cephFsEnabled = "false"
         cephFsEnabled = str(cephFsEnabled).lower()
     else:
         cephEnabled = "false"
@@ -1234,6 +1238,7 @@ def configure_cdk_addons():
         'enable-cephfs='+cephFsEnabled,
         'ceph-admin-key=' + (ceph.get('admin_key', '')),
         'ceph-fsid=' + (ceph.get('fsid', '')),
+        'ceph-fsname='+ (ceph.get('fsname', '')),
         'ceph-kubernetes-key=' + (ceph.get('admin_key', '')),
         'ceph-mon-hosts="' + (ceph.get('mon_hosts', '')) + '"',
         'default-storage=' + default_storage,

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1237,7 +1237,7 @@ def configure_cdk_addons():
         'enable-cephfs='+cephFsEnabled,
         'ceph-admin-key=' + (ceph.get('admin_key', '')),
         'ceph-fsid=' + (ceph.get('fsid', '')),
-        'ceph-fsname='+ (ceph.get('fsname', '')),
+        'ceph-fsname=' + (ceph.get('fsname', '')),
         'ceph-kubernetes-key=' + (ceph.get('admin_key', '')),
         'ceph-mon-hosts="' + (ceph.get('mon_hosts', '')) + '"',
         'default-storage=' + default_storage,

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ commands = pytest --tb native -s {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py3
-commands = flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests
+commands = flake8 {toxinidir}/reactive {toxinidir}/lib {toxinidir}/tests {toxinidir}/actions


### PR DESCRIPTION
The name of the CephFS file system created by the ceph-fs charm is not hard-coded. Instead, it is set to the application name that the ceph-fs charm was deployed with, which we cannot determine via Juju because we have no direct relation to ceph-fs. So we have to query ceph to find the correct value to use for fsName.