### PR TITLE
Write and pass in kubeconfig for cdk-addons

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -115,6 +115,7 @@ configure_prefix = 'kubernetes-master.prev_args.'
 keystone_root = '/root/cdk/keystone'
 keystone_policy_path = os.path.join(keystone_root, 'keystone-policy.yaml')
 kubecontrollermanagerconfig_path = '/root/cdk/kubecontrollermanagerconfig'
+cdk_addons_kubectl_config_path = '/root/cdk/cdk_addons_kubectl_config'
 aws_iam_webhook = '/root/cdk/aws-iam-webhook.yaml'
 
 register_trigger(when='endpoint.aws.ready',  # when set
@@ -1226,6 +1227,7 @@ def configure_cdk_addons():
         cluster_tag = 'kubernetes'
 
     args = [
+        'kubeconfig=' + cdk_addons_kubectl_config_path,
         'arch=' + arch(),
         'dns-ip=' + get_deprecated_dns_ip(),
         'dns-domain=' + hookenv.config('dns_domain'),
@@ -1699,6 +1701,10 @@ def build_kubeconfig():
         # make a copy in a location shared by kubernetes-worker
         # and kubernete-master
         create_kubeconfig(kubeclientconfig_path, server, ca_crt_path,
+                          user='admin', password=client_pass)
+
+        # make a copy for cdk-addons to use
+        create_kubeconfig(cdk_addons_kubectl_config_path, server, ca_crt_path,
                           user='admin', password=client_pass)
 
         # make a kubeconfig for kube-proxy


### PR DESCRIPTION
It seems that cdk-addons has always expected a kubeconfig snap config to be passed in with a path to the kubectl config file to use, but k8s-master has never actually created and set that. It happened to work by accident up until now, since kubectl would try localhost:8080 which happened to work. It seems the latest kubectl getting built into cdk-addons no longer falls back to localhost:8080 (see [k8s PR#86173](https://github.com/kubernetes/kubernetes/pull/86173)), so this uncovered the fact that we were not giving an explicit config.