### PR TITLE
Use local apiserver for kubectl operations

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -146,6 +146,8 @@ register_trigger(when='kubernetes-master.gcp.changed',
                  set_flag='cdk-addons.reconfigure')
 register_trigger(when='kubernetes-master.openstack.changed',
                  set_flag='cdk-addons.reconfigure')
+register_trigger(when_not='cni.available',
+                 clear_flag='kubernetes-master.components.started')
 
 
 def set_upgrade_needed(forced=False):


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1869246

Removing the kubernetes-master leader unit takes forever now, because cdk-addons.apply runs in every hook and times out trying to reach the kubernetes-master public address:

```
unit-kubernetes-master-1: 12:57:23 INFO unit.kubernetes-master/1.juju-log cni:14: Invoking reactive handler: reactive/kubernetes_master.py:1143:configure_cdk_addons
unit-kubernetes-master-1: 12:58:22 DEBUG unit.unit-kubernetes-master-1.collect-metrics Unable to connect to the server: dial tcp 54.245.61.177:6443: i/o timeout
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken Unable to connect to the server: dial tcp 54.245.61.177:6443: i/o timeout
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken Traceback (most recent call last):
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken File "/snap/cdk-addons/1820/apply", line 359, in <module>
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken main()
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken File "/snap/cdk-addons/1820/apply", line 28, in main
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken if render_templates():
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken File "/snap/cdk-addons/1820/apply", line 35, in render_templates
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken node_count = get_node_count()
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken File "/snap/cdk-addons/1820/apply", line 343, in get_node_count
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken output = kubectl("get", "nodes", "-o", "name")
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken File "/snap/cdk-addons/1820/apply", line 339, in kubectl
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken return subprocess.check_output(cmd).decode('utf-8')
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken File "/usr/lib/python3.5/subprocess.py", line 626, in check_output
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken **kwargs).stdout
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken File "/usr/lib/python3.5/subprocess.py", line 708, in run
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken output=stdout, stderr=stderr)
unit-kubernetes-master-1: 12:59:54 DEBUG unit.kubernetes-master/1.cni-relation-broken subprocess.CalledProcessError: Command '['/snap/cdk-addons/1820/kubectl', '--kubeconfig', '/root/cdk/cdk_addons_kubectl_config', 'get', 'nodes', '-o', 'name']' returned non-zero exit stat
unit-kubernetes-master-1: 12:59:54 INFO unit.kubernetes-master/1.juju-log cni:14: Addons are not ready yet.
```

The application is not exposed in Juju, so connection attempts to the public address are blocked by cloud firewalls.

This PR updates all kubeconfigs to point to the local unit's private address, except for `/home/ubuntu/config` which still points to the public address since it's meant to be copied out of the cluster and used by users.

I am testing this now.