### PR TITLE
Fix hook error on xenial when related to ceph-mon

### DIFF
--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -114,7 +114,7 @@ def query_cephfs_enabled():
     try:
         out = check_output(['ceph', 'mds', 'versions',
                             '-c', str(CEPH_CONF)])
-        return bool(json.loads(out))
+        return bool(json.loads(out.decode()))
     except CalledProcessError:
         hookenv.log('Unable to determine if CephFS is enabled', 'ERROR')
         return False


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1870383

I've tested this on both xenial and bionic deployments and confirmed that the hook error no longer occurs on xenial.