### PR TITLE
Explicitly use bash

### DIFF
--- a/actions/upgrade
+++ b/actions/upgrade
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
 
 if [[ "$(action-get fix-cluster-name)" == "true" ]]; then


### PR DESCRIPTION
Since `[[` is a bash feature and not part of plain sh it should be used instead in the shebang to prevent errors when the wrong shell is configured as default.