### PR TITLE
Use openstack-integrator to configure k8s-keystone-auth 

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1705,7 +1705,8 @@ def build_kubeconfig():
                 tls_ca_filename = 'tls-ca.pem'
                 tls_ca_path = os.path.join(os.sep, 'home', 'ubuntu',
                                            tls_ca_filename)
-                host.write_file(tls_ca_path, base64.b64decode(openstack.endpoint_tls_ca))
+                host.write_file(tls_ca_path,
+                                base64.b64decode(openstack.endpoint_tls_ca))
             context = {'protocol': auth_url_parsed.scheme,
                        'address': auth_url_parsed.hostname,
                        'port': auth_url_parsed.port,
@@ -2498,7 +2499,8 @@ def generate_keystone_configmap():
 
 
 @when('leadership.is_leader', 'kubernetes-master.keystone-policy-handled')
-@when_not_all('keystone-credentials.available.auth', 'endpoint.openstack.ready')
+@when_not_all('keystone-credentials.available.auth',
+              'endpoint.openstack.ready')
 def remove_keystone():
     clear_flag('kubernetes-master.apiserver.configured')
     if not os.path.exists(keystone_policy_path):
@@ -2529,7 +2531,8 @@ def keystone_kick_apiserver():
 
 
 @when('certificates.ca.available', 'certificates.client.cert.available',
-      'authentication.setup', 'etcd.available', 'leadership.set.keystone-cdk-addons-configured')
+      'authentication.setup', 'etcd.available',
+      'leadership.set.keystone-cdk-addons-configured')
 @when_any('keystone-credentials.available.auth', 'endpoint.openstack.ready')
 def keystone_config():
     # first, we have to have the service set up before we can render this stuff

--- a/templates/kube-keystone.sh
+++ b/templates/kube-keystone.sh
@@ -14,6 +14,7 @@
 
 # Replace with your public address and port for keystone
 export OS_AUTH_URL="{{ protocol }}://{{ address }}:{{ port }}/v{{ version }}"
+export CURL_CA_BUNDLE="{{ endpoint_tls_ca }}"
 #export OS_PROJECT_NAME=k8s
 #export OS_DOMAIN_NAME=k8s
 #export OS_USERNAME=myuser


### PR DESCRIPTION
Use credentials obtained from openstack-integrator to also configure k8s-keystone-auth which would allow a Kubernetes deployment to avoid using a CMR relation to a controller of the underlying cloud.
https://bugs.launchpad.net/charm-kubernetes-master/+bug/1834164