### PR TITLE
Fix prometheus targets failing due to missing port and RBAC role

### DIFF
--- a/templates/prometheus/kubernetes-cadvisor.yaml.j2
+++ b/templates/prometheus/kubernetes-cadvisor.yaml.j2
@@ -14,7 +14,7 @@ relabel_configs:
 - action: labelmap
   regex: __meta_kubernetes_node_label_(.+)
 - target_label: __address__
-  replacement: {{k8s_api_address}}
+  replacement: {{k8s_api_address}}:{{k8s_api_port}}
 - source_labels: [__meta_kubernetes_node_name]
   regex: (.+)
   target_label: __metrics_path__

--- a/templates/prometheus/kubernetes-nodes.yaml.j2
+++ b/templates/prometheus/kubernetes-nodes.yaml.j2
@@ -14,7 +14,7 @@ relabel_configs:
 - action: labelmap
   regex: __meta_kubernetes_node_label_(.+)
 - target_label: __address__
-  replacement: {{k8s_api_address}}
+  replacement: {{k8s_api_address}}:{{k8s_api_port}}
 - source_labels: [__meta_kubernetes_node_name]
   regex: (.+)
   target_label: __metrics_path__

--- a/templates/system-monitoring-rbac-role.yaml
+++ b/templates/system-monitoring-rbac-role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:monitoring
+rules:
+- apiGroups: [""]
+  resources:
+  - "endpoints"
+  - "nodes"
+  - "nodes/proxy"
+  - "pods"
+  - "services"
+  - "services/proxy"
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:monitoring


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1866672

Tested by deploying this with cs:kubernetes-core (no kubeapi-load-balancer) and authorization-mode=Node,RBAC. I confirmed that the snap.prometheus.prometheus service no longer logs scraping errors, and that all prometheus targets now appear as `UP`.