### PR TITLE
support for service-cidr expansion

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -168,6 +168,42 @@ def channel_changed():
     set_upgrade_needed()
 
 
+# Returns True if a is subnet of b
+# This method is copied from cpython as it is available only from
+# python 3.7
+# https://github.com/python/cpython/blob/3.7/Lib/ipaddress.py#L1000
+def is_subnet_of(a, b):
+    try:
+        # Always false if one is v4 and the other is v6.
+        if a._version != b._version:
+            raise TypeError("{} and {} are not of the same version".format(
+                a, b))
+        return (b.network_address <= a.network_address and
+                b.broadcast_address >= a.broadcast_address)
+    except AttributeError:
+        raise TypeError("Unable to test subnet containment "
+                        "between {} and {}".format(a, b))
+
+
+def is_service_cidr_expansion():
+    service_cidr_from_db = db.get('kubernetes-master.service-cidr')
+    service_cidr_from_config = hookenv.config('service-cidr')
+    if not service_cidr_from_db:
+        return False
+
+    # Do not consider as expansion if both old and new service cidr are same
+    if service_cidr_from_db == service_cidr_from_config:
+        return False
+
+    current_service_cidr = ipaddress.ip_network(service_cidr_from_db)
+    new_service_cidr = ipaddress.ip_network(service_cidr_from_config)
+    if not is_subnet_of(current_service_cidr, new_service_cidr):
+        hookenv.log("WARN: New k8s service cidr not superset of old one")
+        return False
+
+    return True
+
+
 def service_cidr():
     ''' Return the charm's service-cidr config '''
     frozen_cidr = db.get('kubernetes-master.service-cidr')
@@ -177,7 +213,10 @@ def service_cidr():
 def freeze_service_cidr():
     ''' Freeze the service CIDR. Once the apiserver has started, we can no
     longer safely change this value. '''
-    db.set('kubernetes-master.service-cidr', service_cidr())
+    frozen_service_cidr = db.get('kubernetes-master.service-cidr')
+    if not frozen_service_cidr or is_service_cidr_expansion():
+        db.set('kubernetes-master.service-cidr', hookenv.config(
+            'service-cidr'))
 
 
 def maybe_install_kube_proxy():
@@ -1594,7 +1633,8 @@ def on_config_allow_privileged_change():
 @when_any('config.changed.api-extra-args',
           'config.changed.audit-policy',
           'config.changed.audit-webhook-config',
-          'config.changed.enable-keystone-authorization')
+          'config.changed.enable-keystone-authorization',
+          'config.changed.service-cidr')
 @when('kubernetes-master.components.started')
 @when('leadership.set.auto_storage_backend')
 @when('etcd.available')
@@ -1801,6 +1841,10 @@ def configure_apiserver():
         # No point in trying to start master services and fail. Just return.
         return
 
+    # Update unit db service-cidr
+    was_service_cidr_expanded = is_service_cidr_expansion()
+    freeze_service_cidr()
+
     api_opts = {}
 
     if is_privileged():
@@ -1973,6 +2017,37 @@ def configure_apiserver():
     configure_kubernetes_service(configure_prefix, 'kube-apiserver',
                                  api_opts, 'api-extra-args')
     service_restart('snap.kube-apiserver.daemon')
+
+    if was_service_cidr_expanded and is_state('leadership.is_leader'):
+        try:
+            hookenv.log("service-cidr expansion: Deleting service kubernetes")
+            kubectl('delete', 'service', 'kubernetes')
+
+            # Restart the cdk-addons
+            # Get deployments/daemonsets/statefulsets
+            hookenv.log("service-cidr expansion: Restart the cdk-addons")
+            output = kubectl(
+                'get', 'daemonset,deployment,statefulset',
+                '-o', 'json',
+                '--all-namespaces',
+                '-l', 'cdk-restart-on-ca-change=true'
+            ).decode('UTF-8')
+            deployments = json.loads(output)['items']
+
+            # Now restart the addons
+            for deployment in deployments:
+                kind = deployment['kind']
+                namespace = deployment['metadata']['namespace']
+                name = deployment['metadata']['name']
+                hookenv.log('Restarting addon: {0} {1} {2}'.format(kind,
+                                                                   namespace,
+                                                                   name))
+                kubectl(
+                    'rollout', 'restart', kind + '/' + name,
+                    '-n', namespace
+                )
+        except Exception:
+            hookenv.log("service-cidr-expansion: k8s services not yet started")
 
     set_flag('kubernetes-master.apiserver.configured')
 

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -1,8 +1,9 @@
 import pytest
 from unittest import mock
 from reactive import kubernetes_master
+from charms.layer.kubernetes_common import get_version, kubectl
 from charms.reactive import endpoint_from_flag, remove_state
-from charmhelpers.core import hookenv
+from charmhelpers.core import hookenv, unitdata
 
 
 def patch_fixture(patch_target):
@@ -36,3 +37,32 @@ def test_series_upgrade():
     kubernetes_master.post_series_upgrade()
     assert kubernetes_master.service_pause.call_count == 4
     assert kubernetes_master.service_resume.call_count == 4
+
+
+@mock.patch('builtins.open', mock.mock_open())
+@mock.patch('os.makedirs', mock.Mock(return_value=0))
+def configure_apiserver(service_cidr_from_db, service_cidr_from_config,
+                        kubectl_call_count):
+    db = unitdata.kv()
+    db.get.return_value = service_cidr_from_db
+    hookenv.config.return_value = service_cidr_from_config
+    get_version.return_value = (1, 18)
+    kubectl.return_value = '{"items": []}'.encode('UTF-8')
+    kubernetes_master.configure_apiserver()
+    assert kubectl.call_count == kubectl_call_count
+
+
+def test_service_cidr_greenfield_deploy():
+    configure_apiserver(None, '10.152.183.0/24', 0)
+
+
+def test_service_cidr_no_change():
+    configure_apiserver('10.152.183.0/24', '10.152.183.0/24', 0)
+
+
+def test_service_cidr_non_expansion():
+    configure_apiserver('10.152.183.0/24', '10.154.183.0/24', 0)
+
+
+def test_service_cidr_expansion():
+    configure_apiserver('10.152.183.0/24', '10.152.0.0/16', 2)


### PR DESCRIPTION
kubernetes-master charm does not allow service-cidr to be changed
once k8s is deployed. However k8s by itself supports service-cidr
expansion. This PR adds support for service-cidr expansion in
kubernetes-master charm.

The charm checks whether the new service-cidr is an expansion or not.
If it is not an expansion, a warning message is displayed on the
status line.

For expansion case,
* regenerate API certs
* update kube-apiserver parameters
* restart kube-apiserver apiservice
* delete kubernetes service object
* rollout cdk-addon services

Closes-Bug: #1868685