### PR TITLE
remove basic-auth from k8s-master

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -275,6 +275,8 @@ options:
       Method of authentication for the Kubernetes dashboard. Allowed values are "auto", 
       "basic", and "token". If set to "auto", basic auth is used unless Keystone is 
       related to kubernetes-master, in which case token auth is used.
+
+      DEPRECATED: this option has no effect on Kubernetes 1.19 and above.
     default: "auto"
   loadbalancer-ips:
     type: string
@@ -301,6 +303,7 @@ options:
         hostPath:
           path: /grafana
           type: Directory
+
       DEPRECATED: this option has no effect on Kubernetes 1.18 and above.
     default: |
       influxdb:

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1747,11 +1747,11 @@ def build_kubeconfig():
 
         if ks:
             create_kubeconfig(kubeconfig_path, public_server, ca_crt_path,
-                              user='admin', password=client_pass,
+                              user='admin', token=client_pass,
                               keystone=True, aws_iam_cluster_id=cluster_id)
         else:
             create_kubeconfig(kubeconfig_path, public_server, ca_crt_path,
-                              user='admin', password=client_pass,
+                              user='admin', token=client_pass,
                               aws_iam_cluster_id=cluster_id)
 
         # Make the config file readable by the ubuntu users so juju scp works.
@@ -1761,11 +1761,11 @@ def build_kubeconfig():
         # make a copy in a location shared by kubernetes-worker
         # and kubernete-master
         create_kubeconfig(kubeclientconfig_path, local_server, ca_crt_path,
-                          user='admin', password=client_pass)
+                          user='admin', token=client_pass)
 
         # make a copy for cdk-addons to use
         create_kubeconfig(cdk_addons_kubectl_config_path, local_server,
-                          ca_crt_path, user='admin', password=client_pass)
+                          ca_crt_path, user='admin', token=client_pass)
 
         # make a kubeconfig for kube-proxy
         proxy_token = get_token('system:kube-proxy')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1200,7 +1200,6 @@ def configure_cdk_addons():
         return
     metricsEnabled = str(hookenv.config('enable-metrics')).lower()
     default_storage = ''
-    dashboard_auth = str(hookenv.config('dashboard-auth')).lower()
     ceph = {}
     ceph_ep = endpoint_from_flag('ceph-storage.available')
     if (ceph_ep and ceph_ep.key() and
@@ -1235,12 +1234,6 @@ def configure_cdk_addons():
         keystone['keystone-ca'] = hookenv.config('keystone-ssl-ca')
     else:
         keystoneEnabled = "false"
-
-    if dashboard_auth == 'auto':
-        if ks:
-            dashboard_auth = 'token'
-        else:
-            dashboard_auth = 'basic'
 
     enable_aws = str(is_flag_set('endpoint.aws.ready')).lower()
     enable_azure = str(is_flag_set('endpoint.azure.ready')).lower()
@@ -1277,7 +1270,7 @@ def configure_cdk_addons():
         'keystone-key-file=' + keystone.get('key', ''),
         'keystone-server-url=' + keystone.get('url', ''),
         'keystone-server-ca=' + keystone.get('keystone-ca', ''),
-        'dashboard-auth=' + dashboard_auth,
+        'dashboard-auth=token',
         'enable-aws=' + enable_aws,
         'enable-azure=' + enable_azure,
         'enable-gcp=' + enable_gcp,

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -599,8 +599,11 @@ def setup_leader_authentication():
     # send auth files to followers via leadership data
     leader_data = {}
     for f in [basic_auth, known_tokens, service_key]:
-        with open(f, 'r') as fp:
-            leader_data[f] = fp.read()
+        try:
+            with open(f, 'r') as fp:
+                leader_data[f] = fp.read()
+        except FileNotFoundError:
+            pass
 
     # this is slightly opaque, but we are sending file contents under its file
     # path as a key.

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length = 88
+
 [tox]
 skipsdist = True
 envlist = lint,py3


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1841226

Quite a bit goes into this:
- deprecate the `dashboard-auth` config option
- `s/setup_basic_auth/setup_tokens` for the admin user
- ensure `setup_tokens` updates existing tokens instead of just appending new rows
- on upgrade, merge leader `basic_auth.csv` into `known_tokens.csv` and genericize basic_auth.csv
- ensure leader sets appropriate data so `basic_auth.csv` is genericized across the cluster
- generate kube_configs based on tokens instead of passwords