### PR TITLE
get_password() should handle non-csv lines; unit test get_password

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2191,8 +2191,12 @@ def get_password(csv_fname, user):
     with open(tokens_fname, 'r') as stream:
         for line in stream:
             record = line.split(',')
-            if record[1] == user:
-                return record[0]
+            try:
+                if record[1] == user:
+                    return record[0]
+            except IndexError:
+                # probably a blank line or comment; move on
+                continue
     return None
 
 

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -38,13 +38,15 @@ def test_get_password(auth_file):
     # Test we handle a missing file
     assert kubernetes_master.get_password('missing', user) is None
 
-    # Test we handle a deprecated file
-    deprecate_auth_file(auth_file)
-    assert kubernetes_master.get_password(auth_file, user) is None
+    with mock.patch('reactive.kubernetes_master.os.path.join',
+                    return_value=str(auth_file)):
+        # Test we handle a deprecated file
+        deprecate_auth_file(auth_file)
+        assert kubernetes_master.get_password(auth_file, user) is None
 
-    # Test we handle a valid file
-    auth_file.write_text('{},{},uid,group\n'.format(password, user))
-    assert kubernetes_master.get_password(auth_file, user) == password
+        # Test we handle a valid file
+        auth_file.write_text('{},{},uid,group\n'.format(password, user))
+        assert kubernetes_master.get_password(auth_file, user) == password
 
 
 def test_send_default_cni():

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -24,10 +24,27 @@ def auth_file():
 
 
 def test_deprecate_auth_file(auth_file):
-    """Verify a comment is written by deprecate_auth_file()"""
+    """Verify a comment is written by deprecate_auth_file()."""
     deprecate_auth_file(auth_file)
     assert auth_file.exists()
     assert auth_file.read_text().startswith('#')
+
+
+def test_get_password(auth_file):
+    """Verify expected token is returned."""
+    password = 'password'
+    user = 'admin'
+
+    # Test we handle a missing file
+    assert kubernetes_master.get_password('missing', user) is None
+
+    # Test we handle a deprecated file
+    deprecate_auth_file(auth_file)
+    assert kubernetes_master.get_password(auth_file, user) is None
+
+    # Test we handle a valid file
+    auth_file.write_text('{},{},uid,group\n'.format(password, user))
+    assert kubernetes_master.get_password(auth_file, user) == password
 
 
 def test_send_default_cni():


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1881324