### PR TITLE
Fix service-cidr expansion race condition

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -822,6 +822,11 @@ def set_final_status():
                                       'to secure secrets')
         return
 
+    if is_state('kubernetes-master.had-service-cidr-expanded'):
+        hookenv.status_set('waiting',
+                           'Waiting to retry updates for service-cidr expansion')
+        return
+
     if is_state('kubernetes-master.components.started'):
         # All services should be up and running at this point. Double-check...
         failing_services = master_services_down()
@@ -2063,37 +2068,77 @@ def configure_apiserver():
     service_restart('snap.kube-apiserver.daemon')
 
     if was_service_cidr_expanded and is_state('leadership.is_leader'):
-        try:
-            hookenv.log("service-cidr expansion: Deleting service kubernetes")
-            kubectl('delete', 'service', 'kubernetes')
-
-            # Restart the cdk-addons
-            # Get deployments/daemonsets/statefulsets
-            hookenv.log("service-cidr expansion: Restart the cdk-addons")
-            output = kubectl(
-                'get', 'daemonset,deployment,statefulset',
-                '-o', 'json',
-                '--all-namespaces',
-                '-l', 'cdk-restart-on-ca-change=true'
-            ).decode('UTF-8')
-            deployments = json.loads(output)['items']
-
-            # Now restart the addons
-            for deployment in deployments:
-                kind = deployment['kind']
-                namespace = deployment['metadata']['namespace']
-                name = deployment['metadata']['name']
-                hookenv.log('Restarting addon: {0} {1} {2}'.format(kind,
-                                                                   namespace,
-                                                                   name))
-                kubectl(
-                    'rollout', 'restart', kind + '/' + name,
-                    '-n', namespace
-                )
-        except Exception:
-            hookenv.log("service-cidr-expansion: k8s services not yet started")
+        set_flag('kubernetes-master.had-service-cidr-expanded')
 
     set_flag('kubernetes-master.apiserver.configured')
+
+
+@when('kubernetes-master.had-service-cidr-expanded',
+      'kubernetes-master.apiserver.configured',
+      'leadership.is_leader')
+def update_for_service_cidr_expansion():
+    # We just restarted the API server, so there's a decent chance it's
+    # not up yet. Keep trying to get the svcs list until we can; get_svcs
+    # has a built-in retry and delay, so this should try for around 30s.
+    def _wait_for_svc_ip():
+        for attempt in range(10):
+            svcs = get_svcs()
+            if svcs:
+                svc_ip = {svc['metadata']['name']: svc['spec']['clusterIP']
+                          for svc in svcs['items']}.get('kubernetes')
+                if svc_ip:
+                    return svc_ip
+        else:
+            return None
+
+    hookenv.log('service-cidr expansion: Waiting for API service')
+    expected_service_ip = get_kubernetes_service_ip()
+    actual_service_ip = _wait_for_svc_ip()
+    if not actual_service_ip:
+        hookenv.log('service-cidr expansion: Timed out waiting for API service')
+        return
+    try:
+        if actual_service_ip != expected_service_ip:
+            hookenv.log("service-cidr expansion: Deleting service kubernetes")
+            kubectl('delete', 'service', 'kubernetes')
+            actual_service_ip = _wait_for_svc_ip()
+            if not actual_service_ip:
+                # we might need another restart to get the service recreated
+                hookenv.log("service-cidr expansion: Timed out waiting for "
+                            "the service to return; restarting API server")
+                clear_flag('kubernetes-master.apiserver.configured')
+                return
+            if actual_service_ip != expected_service_ip:
+                raise ValueError('Unexpected service IP: {} != {}'.format(
+                    actual_service_ip, expected_service_ip))
+
+        # Restart the cdk-addons
+        # Get deployments/daemonsets/statefulsets
+        hookenv.log("service-cidr expansion: Restart the cdk-addons")
+        output = kubectl(
+            'get', 'daemonset,deployment,statefulset',
+            '-o', 'json',
+            '--all-namespaces',
+            '-l', 'cdk-restart-on-ca-change=true'
+        ).decode('UTF-8')
+        deployments = json.loads(output)['items']
+
+        # Now restart the addons
+        for deployment in deployments:
+            kind = deployment['kind']
+            namespace = deployment['metadata']['namespace']
+            name = deployment['metadata']['name']
+            hookenv.log('Restarting addon: {0} {1} {2}'.format(kind,
+                                                               namespace,
+                                                               name))
+            kubectl(
+                'rollout', 'restart', kind + '/' + name,
+                '-n', namespace
+            )
+    except CalledProcessError:
+        hookenv.log('service-cidr expansion: failed to restart components')
+    else:
+        clear_flag('kubernetes-master.had-service-cidr-expanded')
 
 
 def configure_controller_manager():
@@ -2235,6 +2280,22 @@ def get_pods(namespace='default'):
         result = json.loads(output)
     except CalledProcessError:
         hookenv.log('failed to get {} pod status'.format(namespace))
+        return None
+    return result
+
+
+@retry(times=3, delay_secs=1)
+def get_svcs(namespace='default'):
+    try:
+        output = kubectl(
+            'get', 'svc',
+            '-n', namespace,
+            '-o', 'json',
+            '--request-timeout', '10s'
+        ).decode('UTF-8')
+        result = json.loads(output)
+    except CalledProcessError:
+        hookenv.log('failed to get {} service status'.format(namespace))
         return None
     return result
 

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2136,6 +2136,8 @@ def update_for_service_cidr_expansion():
                 '-n', namespace
             )
     except CalledProcessError:
+        # the kubectl calls already log the command and don't capture stderr,
+        # so logging the exception is a bit superfluous
         hookenv.log('service-cidr expansion: failed to restart components')
     else:
         clear_flag('kubernetes-master.had-service-cidr-expanded')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,4 @@ import charms.unit_test
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module('charms.coordinator')
 charms.unit_test.patch_module('charms.leadership')
+charms.layer.kubernetes_common.retry.return_value = charms.unit_test.identity

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import tempfile
 from pathlib import Path
@@ -5,7 +6,7 @@ from unittest import mock
 from reactive import kubernetes_master
 from charms.layer.kubernetes_common import get_version, kubectl
 from charms.layer.kubernetes_master import deprecate_auth_file
-from charms.reactive import endpoint_from_flag, remove_state
+from charms.reactive import endpoint_from_flag, set_flag, is_flag_set
 from charmhelpers.core import hookenv, unitdata
 
 
@@ -57,10 +58,9 @@ def test_send_default_cni():
 
 
 def test_default_cni_changed():
+    set_flag('kubernetes-master.components.started')
     kubernetes_master.default_cni_changed()
-    remove_state.assert_called_once_with(
-        'kubernetes-master.components.started'
-    )
+    assert not is_flag_set('kubernetes-master.components.started')
 
 
 def test_series_upgrade():
@@ -76,28 +76,54 @@ def test_series_upgrade():
 
 @mock.patch('builtins.open', mock.mock_open())
 @mock.patch('os.makedirs', mock.Mock(return_value=0))
-def configure_apiserver(service_cidr_from_db, service_cidr_from_config,
-                        kubectl_call_count):
+def configure_apiserver(service_cidr_from_db, service_cidr_from_config):
+    set_flag('leadership.is_leader')
     db = unitdata.kv()
     db.get.return_value = service_cidr_from_db
     hookenv.config.return_value = service_cidr_from_config
     get_version.return_value = (1, 18)
-    kubectl.return_value = '{"items": []}'.encode('UTF-8')
     kubernetes_master.configure_apiserver()
-    assert kubectl.call_count == kubectl_call_count
+
+
+def update_for_service_cidr_expansion():
+    def _svc(clusterIP):
+        return json.dumps({
+            "items": [
+                {
+                    "metadata": {"name": "kubernetes"},
+                    "spec": {"clusterIP": clusterIP},
+                }
+            ]
+        }).encode('utf8')
+
+    kubectl.side_effect = [
+        _svc('10.152.183.1'),
+        None,
+        _svc('10.152.0.1'),
+        b'{"items":[]}',
+    ]
+    assert kubectl.call_count == 0
+    kubernetes_master.update_for_service_cidr_expansion()
 
 
 def test_service_cidr_greenfield_deploy():
-    configure_apiserver(None, '10.152.183.0/24', 0)
+    configure_apiserver(None, '10.152.183.0/24')
+    assert not is_flag_set('kubernetes-master.had-service-cidr-expanded')
 
 
 def test_service_cidr_no_change():
-    configure_apiserver('10.152.183.0/24', '10.152.183.0/24', 0)
+    configure_apiserver('10.152.183.0/24', '10.152.183.0/24')
+    assert not is_flag_set('kubernetes-master.had-service-cidr-expanded')
 
 
 def test_service_cidr_non_expansion():
-    configure_apiserver('10.152.183.0/24', '10.154.183.0/24', 0)
+    configure_apiserver('10.152.183.0/24', '10.154.183.0/24')
+    assert not is_flag_set('kubernetes-master.had-service-cidr-expanded')
 
 
 def test_service_cidr_expansion():
-    configure_apiserver('10.152.183.0/24', '10.152.0.0/16', 2)
+    configure_apiserver('10.152.183.0/24', '10.152.0.0/16')
+    assert is_flag_set('kubernetes-master.had-service-cidr-expanded')
+    unitdata.kv().get.return_value = '10.152.0.0/16'
+    update_for_service_cidr_expansion()
+    assert kubectl.call_count == 4


### PR DESCRIPTION
The logic for handling service-cidr expansion doesn't gracefully handle the case where the API server doesn't come up quickly enough. There's also some question as to whether the API server might need to be restarted after the service is deleted, so check for and handle that.

Fixes [lp:1879785](https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1879785)