### PR TITLE
Add CIS benchmark requirements to k8s master

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -148,7 +148,7 @@ options:
         --runtime-config=batch/v2alpha1=true --profiling=true
   authorization-mode:
     type: string
-    default: "AlwaysAllow"
+    default: "RBAC,Node"
     description: |
       Comma separated authorization modes. Allowed values are
       "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow".
@@ -272,8 +272,8 @@ options:
   dashboard-auth:
     type: string
     description: |
-      Method of authentication for the Kubernetes dashboard. Allowed values are "auto", 
-      "basic", and "token". If set to "auto", basic auth is used unless Keystone is 
+      Method of authentication for the Kubernetes dashboard. Allowed values are "auto",
+      "basic", and "token". If set to "auto", basic auth is used unless Keystone is
       related to kubernetes-master, in which case token auth is used.
 
       DEPRECATED: this option has no effect on Kubernetes 1.19 and above.

--- a/config.yaml
+++ b/config.yaml
@@ -148,7 +148,7 @@ options:
         --runtime-config=batch/v2alpha1=true --profiling=true
   authorization-mode:
     type: string
-    default: "RBAC,Node"
+    default: "Node,RBAC"
     description: |
       Comma separated authorization modes. Allowed values are
       "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow".

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1964,11 +1964,11 @@ def configure_apiserver():
 
     admission_plugins = [
         'PersistentVolumeLabel',
+        'PodSecurityPolicy',
+        'NodeRestriction'
     ]
 
     auth_mode = hookenv.config('authorization-mode')
-    if 'Node' in auth_mode:
-        admission_plugins.append('NodeRestriction')
 
     ks = endpoint_from_flag('keystone-credentials.available.auth')
     aws = endpoint_from_flag('endpoint.aws-iam.ready')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1007,8 +1007,6 @@ def add_systemd_file_watcher():
           'tls_client.certs.changed',
           'tls_client.ca.written',
           'upgrade.series.in-progress')
-
-
 def start_master():
     '''Run the Kubernetes master components.'''
     hookenv.status_set('maintenance',

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2187,6 +2187,9 @@ def configure_controller_manager():
     controller_opts['tls-cert-file'] = str(server_crt_path)
     controller_opts['tls-private-key-file'] = str(server_key_path)
     controller_opts['cluster-name'] = leader_get('cluster_tag')
+    controller_opts['terminated-pod-gc-threshold'] = '12500'
+    controller_opts['profiling'] = 'false'
+    controller_opts['feature-gates'] = 'RotateKubeletServerCertificate=true'
 
     cm_cloud_config_path = cloud_config_path('kube-controller-manager')
     if is_state('endpoint.aws.ready'):
@@ -2214,6 +2217,7 @@ def configure_scheduler():
     scheduler_opts['v'] = '2'
     scheduler_opts['logtostderr'] = 'true'
     scheduler_opts['master'] = 'http://127.0.0.1:8080'
+    scheduler_opts['profiling'] = 'false'
 
     configure_kubernetes_service(configure_prefix, 'kube-scheduler',
                                  scheduler_opts, 'scheduler-extra-args')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1944,6 +1944,8 @@ def configure_apiserver():
     api_opts['kubelet-preferred-address-types'] = \
         'InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP'
     api_opts['advertise-address'] = get_ingress_address('kube-control')
+    api_opts['encryption-provider-config'] = \
+        str(encryption_config_path())
 
     etcd_dir = '/root/cdk/etcd'
     etcd_ca = os.path.join(etcd_dir, 'client-ca.pem')
@@ -2080,13 +2082,6 @@ def configure_apiserver():
         api_opts['audit-webhook-config-file'] = audit_webhook_config_path
     else:
         remove_if_exists(audit_webhook_config_path)
-
-    if kube_version > (1, 8):
-        api_opts['encryption-provider-config'] = \
-            str(encryption_config_path())
-    else:
-        api_opts['experimental-encryption-provider-config'] = \
-            str(encryption_config_path())
 
     configure_kubernetes_service(configure_prefix, 'kube-apiserver',
                                  api_opts, 'api-extra-args')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1577,6 +1577,22 @@ def switch_auth_mode(forced=False):
 
 
 @when('leadership.is_leader',
+      'kubernetes-master.components.started')
+@when_not('kubernetes-master.pod-security-policy.applied')
+def create_pod_security_policy_resources():
+    pod_security_policy_path = '/root/cdk/pod-security-policy.yaml'
+
+    render('rbac-pod-security-policy.yaml')
+
+    hookenv.log('Creating pod security policy resources.')
+    if kubectl_manifest('apply', pod_security_policy_path):
+        set_state('kubernetes-master.pod-security-policy.applied')
+    else:
+        msg = 'Failed to apply {}, will retry.'.format(pod_security_policy_path)
+        hookenv.log(msg)
+
+
+@when('leadership.is_leader',
       'kubernetes-master.components.started',
       'kubernetes-master.create.rbac')
 def create_rbac_resources():

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2250,11 +2250,19 @@ def configure_scheduler():
     scheduler_opts['profiling'] = 'false'
     scheduler_opts['config'] = kube_scheduler_config_path
 
+    scheduler_ver = get_version('kube-scheduler')
+    if scheduler_ver >= (1, 19):
+        api_ver = 'v1beta1'
+    elif scheduler_ver >= (1, 18):
+        api_ver = 'v1alpha2'
+    else:
+        api_ver = 'v1alpha1'
+
     host.write_file(
         path=kube_scheduler_config_path,
         perms=0o600,
         content=yaml.safe_dump({
-            'apiVersion': 'kubescheduler.config.k8s.io/v1alpha1',
+            'apiVersion': 'kubescheduler.config.k8s.io/{}'.format(api_ver),
             'kind': 'KubeSchedulerConfiguration',
             'clientConnection': {
                 'kubeconfig': kubeschedulerconfig_path

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2441,7 +2441,8 @@ def poke_network_unavailable():
 
     for node in nodes:
         node_name = node['metadata']['name']
-        req = Request('{}/api/v1/nodes/{}/status'.format(local_server, node_name))
+        url = '{}/api/v1/nodes/{}/status'.format(local_server, node_name)
+        req = Request(url)
         req.add_header(*http_header)
         with urlopen(req) as response:
             code = response.getcode()

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1012,7 +1012,8 @@ def start_master():
     hookenv.status_set('maintenance',
                        'Configuring the Kubernetes master services.')
 
-    if not is_state('kubernetes-master.vault-kv.pending'):
+    if not is_state('kubernetes-master.vault-kv.pending') \
+            and not is_state('kubernetes-master.secure-storage.created'):
         encryption_config_path().parent.mkdir(parents=True, exist_ok=True)
         host.write_file(
             path=str(encryption_config_path()),

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2467,6 +2467,7 @@ def poke_network_unavailable():
                 req = Request(url, method='PUT',
                               data=json.dumps(node_info).encode('utf8'),
                               headers={'Content-Type': 'application/json'})
+                req.add_header(*http_header)
                 with urlopen(req) as response:
                     code = response.getcode()
                     body = response.read().decode('utf8')

--- a/templates/rbac-pod-security-policy.yaml
+++ b/templates/rbac-pod-security-policy.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: privileged
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - privileged
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: privileged
+roleRef:
+  kind: ClusterRole
+  name: privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  name: system:serviceaccounts
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This results in 

```
[FAIL] 1.2.3 Ensure that the --token-auth-file parameter is not set (Scored)
```

For the API server tests, I believe these will be addressed in the move to webhook auth - please advise if this is incorrect.  Will address the scheduler and controller in other PRs.