### PR TITLE
Fix hook error when removing Ceph relation

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1302,7 +1302,7 @@ def configure_cdk_addons():
     default_storage = ''
     ceph = {}
     ceph_ep = endpoint_from_flag('ceph-storage.available')
-    if (ceph_ep and ceph_ep.key() and
+    if (ceph_ep and ceph_ep.key() and ceph_ep.fsid() and ceph_ep.mon_hosts() and
             is_state('kubernetes-master.ceph.configured') and
             get_version('kube-apiserver') >= (1, 12)):
         cephEnabled = "true"


### PR DESCRIPTION
It seems that there is a possible case where the ceph-storage.available flag is still set and the key is available, but the fsid comes back as None, leading to the following (from CI):

```
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed Traceback (most recent call last):
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed   File "/var/lib/juju/agents/unit-kubernetes-master-1/charm/hooks/ceph-client-relation-departed", line 22, in
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed     main()
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed   File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 74, in main
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed bus.dispatch(restricted=restricted_mode)
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed   File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 390, in dispatch
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed _invoke(other_handlers)
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed   File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 359, in _invoke
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed handler.invoke()
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed   File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 181, in invoke
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed self._action(*args)
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed   File "/var/lib/juju/agents/unit-kubernetes-master-1/charm/reactive/kubernetes_master.py", line 1364, in configure_cdk_addons
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed 'ceph-fsname=' + (ceph.get('fsname', '')),
2020-07-31 02:42:28 DEBUG ceph-client-relation-departed TypeError: must be str, not NoneType
2020-07-31 02:42:29 ERROR juju.worker.uniter.operation runhook.go:132 hook "ceph-client-relation-departed" failed: exit status 1
```

This checks that all of the fields that we use are available.