### PR TITLE
ensure valid default when ceph fsname is unavailable

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1368,10 +1368,9 @@ def configure_cdk_addons():
         default_storage = hookenv.config('default-storage')
         if kubernetes_master.query_cephfs_enabled():
             cephFsEnabled = "true"
-            ceph['fsname'] = kubernetes_master.get_cephfs_fsname()
+            ceph['fsname'] = kubernetes_master.get_cephfs_fsname() or ''
         else:
             cephFsEnabled = "false"
-            ceph['fsname'] = ''
     else:
         cephEnabled = "false"
         cephFsEnabled = "false"

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1371,6 +1371,7 @@ def configure_cdk_addons():
             ceph['fsname'] = kubernetes_master.get_cephfs_fsname()
         else:
             cephFsEnabled = "false"
+            ceph['fsname'] = ''
     else:
         cephEnabled = "false"
         cephFsEnabled = "false"


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1892767

We append ceph[fsname] to the arg string when configuring cdk-addons. Make sure this is an empty string when cephFs is not available.