### PR TITLE
add secret suffix and move to kube-system ns

### DIFF
--- a/actions/user_actions.py
+++ b/actions/user_actions.py
@@ -34,7 +34,7 @@ def protect_resources(name):
 def user_list():
     '''Return a dict of 'username: secret_id' for Charmed Kubernetes users.'''
     output = layer.kubernetes_common.kubectl(
-        'get', 'secrets',
+        'get', 'secrets', '-n', layer.kubernetes_master.AUTH_SECRET_NS,
         '--field-selector', 'type={}'.format(layer.kubernetes_master.AUTH_SECRET_TYPE),
         '-o', 'json').decode('UTF-8')
     secrets = json.loads(output)

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -21,6 +21,8 @@ from charms.layer import kubernetes_common
 
 AUTH_BACKUP_EXT = 'pre-secrets'
 AUTH_BASIC_FILE = '/root/cdk/basic_auth.csv'
+AUTH_SECRET_NS = 'kube-system'
+AUTH_SECRET_SUFFIX = 'token-auth'
 AUTH_SECRET_TYPE = 'juju.is/token-auth'
 AUTH_TOKENS_FILE = '/root/cdk/known_tokens.csv'
 STANDARD_API_PORT = 6443
@@ -232,7 +234,9 @@ def create_known_token(token, username, user, groups=None):
 
 
 def create_secret(token, username, user, groups=None):
-    secret_id = re.sub('[^0-9a-zA-Z]+', '-', user)
+    # secret names can only include alphanum and hyphens
+    sani_name = re.sub('[^0-9a-zA-Z]+', '-', user)
+    secret_id = '{}-{}'.format(sani_name, AUTH_SECRET_SUFFIX)
     # The authenticator expects tokens to be in the form user::token
     token_delim = '::'
     if token_delim not in token:
@@ -240,7 +244,8 @@ def create_secret(token, username, user, groups=None):
 
     context = {
         'type': AUTH_SECRET_TYPE,
-        'secret_id': secret_id,
+        'secret_name': secret_id,
+        'secret_namespace': AUTH_SECRET_NS,
         'user': b64encode(user.encode('UTF-8')).decode('utf-8'),
         'username': b64encode(username.encode('UTF-8')).decode('utf-8'),
         'password': b64encode(token.encode('UTF-8')).decode('utf-8'),
@@ -282,9 +287,10 @@ def get_csv_password(csv_fname, user):
 
 
 def get_secret_password(username):
+    """Get the password for the given user from the secret that CK created."""
     try:
         output = kubernetes_common.kubectl(
-            'get', 'secrets',
+            'get', 'secrets', '-n', AUTH_SECRET_NS,
             '--field-selector', 'type={}'.format(AUTH_SECRET_TYPE),
             '-o', 'json').decode('UTF-8')
     except CalledProcessError:

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -265,7 +265,8 @@ def delete_secret(secret_id):
     '''Delete a given secret id.'''
     # If this fails, it's most likely because we're trying to delete a secret
     # that doesn't exist. Let the caller decide if failure is a problem.
-    return kubernetes_common.kubectl_success('delete', 'secret', secret_id)
+    return kubernetes_common.kubectl_success(
+        'delete', 'secret', '-n', AUTH_SECRET_NS, secret_id)
 
 
 def get_csv_password(csv_fname, user):

--- a/templates/cdk.master.auth-webhook-secret.yaml
+++ b/templates/cdk.master.auth-webhook-secret.yaml
@@ -3,7 +3,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ secret_id }}
+  name: {{ secret_name }}
+  namespace: {{ secret_namespace }}
 type: {{ type }}
 data:
   uid: {{ user }}

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -109,7 +109,7 @@ def check_secrets(token_review):
 
     try:
         output = kubectl(
-            'get', 'secrets', '-A', '-o', 'json').decode('UTF-8')
+            'get', 'secrets', '-n', 'kube-system', '-o', 'json').decode('UTF-8')
     except (CalledProcessError, TimeoutExpired) as e:
         app.logger.info('Unable to load secrets: {}.'.format(e))
         return False
@@ -120,13 +120,13 @@ def check_secrets(token_review):
             try:
                 data_b64 = secret['data']
                 password_b64 = data_b64['password'].encode('UTF-8')
+                username_b64 = data_b64['username'].encode('UTF-8')
             except (KeyError, TypeError):
                 # CK secrets will have populated 'data', but not all secrets do
                 continue
 
             password = b64decode(password_b64).decode('UTF-8')
             if token_to_check == password:
-                username_b64 = data_b64['username'].encode('UTF-8')
                 groups_b64 = data_b64['groups'].encode('UTF-8') \
                     if 'groups' in data_b64 else b''
 

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -88,12 +88,14 @@ def check_token(token_review):
 
     if token_to_check in data_by_token:
         record = data_by_token[token_to_check]
+        # groups are optional; default to an empty string if we don't have any
+        groups = record.get('groups', '').split(',')
         token_review['status'] = {
             'authenticated': True,
             'user': {
                 'username': record['username'],
                 'uid': record['user'],
-                'groups': record['groups'].split(','),
+                'groups': groups,
             }
         }
         return True
@@ -107,7 +109,7 @@ def check_secrets(token_review):
 
     try:
         output = kubectl(
-            'get', 'secrets', '-o', 'json').decode('UTF-8')
+            'get', 'secrets', '-A', '-o', 'json').decode('UTF-8')
     except (CalledProcessError, TimeoutExpired) as e:
         app.logger.info('Unable to load secrets: {}.'.format(e))
         return False

--- a/tests/test_kubernetes_master_lib.py
+++ b/tests/test_kubernetes_master_lib.py
@@ -45,7 +45,7 @@ def test_migrate_auth_file(auth_file):
 @mock.patch('lib.charms.layer.kubernetes_master.kubernetes_common.kubectl_manifest',
             return_value=True)
 def test_create_secret(mock_kubectl, mock_render):
-    """Verify valid secret data is sent to kubectl."""
+    """Verify valid secret data is sent to kubectl during create."""
     password = 'password'
     user_id = 'replace$uid'
     secret_name = 'replace-uid'
@@ -64,8 +64,13 @@ def test_create_secret(mock_kubectl, mock_render):
 @mock.patch('lib.charms.layer.kubernetes_master.kubernetes_common.kubectl_success',
             return_value=True)
 def test_delete_secret(mock_kubectl):
-    """Verify we get a bool back from the kubectl call."""
+    """Verify valid secret data is sent to kubectl during delete."""
+    secret_ns = 'kube-system'
+
+    # We should call kubectl with our namespace and return a bool
     assert charmlib.delete_secret('secret-id')
+    args, kwargs = mock_kubectl.call_args
+    assert secret_ns in args
 
 
 def test_get_csv_password(auth_file):

--- a/tests/test_kubernetes_master_lib.py
+++ b/tests/test_kubernetes_master_lib.py
@@ -48,15 +48,16 @@ def test_create_secret(mock_kubectl, mock_render):
     """Verify valid secret data is sent to kubectl."""
     password = 'password'
     user_id = 'replace$uid'
-    secret_id = 'replace-uid'
+    secret_name = 'replace-uid'
+    secret_ns = 'kube-system'
     secret_token = base64.b64encode(
         '{}::{}'.format(user_id, password).encode('utf-8')).decode('utf-8')
 
-    with mock.patch('lib.charms.layer.kubernetes_master.delete_secret'):
-        charmlib.create_secret(password, 'admin', user_id, 'groupA,groupB')
+    charmlib.create_secret(password, 'admin', user_id, 'groupA,groupB')
     assert mock_kubectl.called
     args, kwargs = mock_render.call_args
-    assert secret_id in kwargs['context']['secret_id']
+    assert secret_name in kwargs['context']['secret_name']
+    assert secret_ns in kwargs['context']['secret_namespace']
     assert secret_token in kwargs['context']['password']
 
 


### PR DESCRIPTION
Continuation of #106 to fix https://bugs.launchpad.net/charm-kubernetes-master/+bug/1878455

After further discussion, we decided that CK secrets were better suited for the `kube-system` namespace.  We also decided that having secret names == user names could lead to a conflict if operators had their own secrets defined -- i.e. a pre-existing secret called `admin` would lead to problems when CK tried to make its own `admin` secret.  We should differentiate CK secrets by adding a suffix to the secret name.

This PR addresses the above with the following:
- manage CK secrets in the kube-system namespace
- add a -suffix to differentiate CK secret names from pre-existing secrets
- drive-by fix to the authenticator for when 'groups' may be missing from a known_tokens.csv entry
- update unit tests

Tested as follows:
- Upgrade
  - deployed 1.18/stable
  - added `passwErd,testuser,testuser,` entry to basic_auth.csv
  - upgraded k8s-master with local charm containing this fix
  - verified csv entries were migrated to secrets with the expected ns and name
    ```bash
    # kubectl get secrets -n kube-system | grep juju
    admin-token-auth                                 juju.is/token-auth                    4      2m41s
    kube-controller-manager-token-auth               juju.is/token-auth                    4      2m42s
    kube-proxy-token-auth                            juju.is/token-auth                    4      2m41s
    kubelet-0-token-auth                             juju.is/token-auth                    4      2m39s
    kubelet-1-token-auth                             juju.is/token-auth                    4      2m40s
    kubelet-2-token-auth                             juju.is/token-auth                    4      2m39s
    system-kube-scheduler-token-auth                 juju.is/token-auth                    4      100s
    system-monitoring-token-auth                     juju.is/token-auth                    4      2m40s
    testuser-token-auth                              juju.is/token-auth                    4      2m38s
    ```
  - verified user actions
    ```bash
    $ juju run-action --wait kubernetes-master/0 user-list
    unit-kubernetes-master-0:
    UnitId: kubernetes-master/0
    id: "1"
    results:
        users: admin, system:kube-controller-manager, system:kube-proxy, system:node:ip-172-31-0-9,
        system:node:ip-172-31-6-64, system:node:ip-172-31-18-237, system:kube-scheduler,
        system:monitoring, testuser
    status: completed

    $ juju run-action --wait kubernetes-master/0 user-create name=testuser2
    unit-kubernetes-master-0:
    UnitId: kubernetes-master/0
    id: "2"
    results:
        Stdout: |
        Cluster "juju-cluster" set.
        Property "users" unset.
        User "testuser2" set.
        Context "juju-context" created.
        Switched to context "juju-context".
        kubeconfig: juju scp kubernetes-master/0:/home/ubuntu/testuser2-kubeconfig .
        msg: User "testuser2" created.
        users: admin, system:kube-controller-manager, system:kube-proxy, system:node:ip-172-31-0-9,
        system:node:ip-172-31-6-64, system:node:ip-172-31-18-237, system:kube-scheduler,
        system:monitoring, testuser, testuser2
    status: completed

    $ juju run-action --wait kubernetes-master/0 user-delete name=testuser
    unit-kubernetes-master-0:
    UnitId: kubernetes-master/0
    id: "3"
    results:
        msg: User "testuser" deleted.
        users: admin, system:kube-controller-manager, system:kube-proxy, system:node:ip-172-31-0-9,
        system:node:ip-172-31-6-64, system:node:ip-172-31-18-237, system:kube-scheduler,
        system:monitoring, testuser2
    status: completed
    ```

- New deployment
  - deployed edge bundle with a k8s-master containing this fix
  - verified secrets were created with the expected ns and name
    ```bash
    # kubectl get secrets -n kube-system | grep juju
    admin-token-auth                                 juju.is/token-auth                    4      64m
    kube-controller-manager-token-auth               juju.is/token-auth                    4      64m
    kube-proxy-token-auth                            juju.is/token-auth                    4      64m
    kubelet-0-token-auth                             juju.is/token-auth                    4      64m
    kubelet-1-token-auth                             juju.is/token-auth                    4      64m
    kubelet-2-token-auth                             juju.is/token-auth                    4      64m
    system-kube-scheduler-token-auth                 juju.is/token-auth                    4      64m
    system-monitoring-token-auth                     juju.is/token-auth                    4      64m
    ```
  - verified user actions
    ```bash
    $ juju run-action --wait kubernetes-master/0 user-list
    unit-kubernetes-master-0:
    UnitId: kubernetes-master/0
    id: "1"
    results:
        users: admin, system:kube-controller-manager, system:kube-proxy, system:node:ip-172-31-11-5,
        system:node:ip-172-31-0-251, system:node:ip-172-31-30-169, system:kube-scheduler,
        system:monitoring
    status: completed

    $ juju run-action --wait kubernetes-master/0 user-create name=testuser2
    unit-kubernetes-master-0:
    UnitId: kubernetes-master/0
    id: "2"
    results:
        Stdout: |
        Cluster "juju-cluster" set.
        Property "users" unset.
        User "testuser2" set.
        Context "juju-context" created.
        Switched to context "juju-context".
        kubeconfig: juju scp kubernetes-master/0:/home/ubuntu/testuser2-kubeconfig .
        msg: User "testuser2" created.
        users: admin, system:kube-controller-manager, system:kube-proxy, system:node:ip-172-31-11-5,
        system:node:ip-172-31-0-251, system:node:ip-172-31-30-169, system:kube-scheduler,
        system:monitoring, testuser2
    status: completed

    $ juju run-action --wait kubernetes-master/0 user-delete name=testuser2
    unit-kubernetes-master-0:
    UnitId: kubernetes-master/0
    id: "4"
    results:
        msg: User "testuser2" deleted.
        users: admin, system:kube-controller-manager, system:kube-proxy, system:node:ip-172-31-11-5,
        system:node:ip-172-31-0-251, system:node:ip-172-31-30-169, system:kube-scheduler,
        system:monitoring
    status: completed
    ```