### PR TITLE
adjust auth-webhook worker count

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -335,11 +335,3 @@ options:
       respond with appropriate authentication details. For more info, please refer
       to the upstream documentation at
       https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
-  authn-webhook-workers:
-    type: int
-    default: 5
-    description: |
-      Number of authenticator webhook service workers. The recommended value is
-      (2 * cores) + 1:
-
-      https://docs.gunicorn.org/en/stable/design.html#how-many-workers

--- a/config.yaml
+++ b/config.yaml
@@ -335,3 +335,11 @@ options:
       respond with appropriate authentication details. For more info, please refer
       to the upstream documentation at
       https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+  authn-webhook-workers:
+    type: int
+    default: 5
+    description: |
+      Number of authenticator webhook service workers. The recommended value is
+      (2 * cores) + 1:
+
+      https://docs.gunicorn.org/en/stable/design.html#how-many-workers

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -967,6 +967,7 @@ def register_auth_webhook():
     context = {'api_ver': 'v1beta1',
                'charm_dir': hookenv.charm_dir(),
                'host': socket.gethostname(),
+               'num_workers': config.get('authn-webhook-workers', 5),
                'pidfile': 'auth-webhook.pid',
                'port': 5000,
                'root_dir': auth_webhook_root}

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -119,6 +119,7 @@ aws_iam_webhook = '/root/cdk/aws-iam-webhook.yaml'
 auth_webhook_root = '/root/cdk/auth-webhook'
 auth_webhook_conf = os.path.join(auth_webhook_root, 'auth-webhook-conf.yaml')
 auth_webhook_exe = os.path.join(auth_webhook_root, 'auth-webhook.py')
+auth_webhook_svc = '/etc/systemd/system/cdk.master.auth-webhook.service'
 
 register_trigger(when='endpoint.aws.ready',  # when set
                  set_flag='kubernetes-master.aws.changed')
@@ -955,6 +956,7 @@ def add_systemd_file_watcher():
 @restart_on_change({
     auth_webhook_conf: ['cdk.master.auth-webhook'],
     auth_webhook_exe: ['cdk.master.auth-webhook'],
+    auth_webhook_svc: ['cdk.master.auth-webhook'],
     })
 def register_auth_webhook():
     '''Render auth webhook templates and start the related service.'''
@@ -1001,8 +1003,7 @@ def register_auth_webhook():
     render('cdk.master.auth-webhook.logrotate',
            '/etc/logrotate.d/auth-webhook', context)
 
-    service_file = '/etc/systemd/system/cdk.master.auth-webhook.service'
-    render('cdk.master.auth-webhook.service', service_file, context)
+    render('cdk.master.auth-webhook.service', auth_webhook_svc, context)
     if not is_flag_set('kubernetes-master.auth-webhook-service.started'):
         check_call(['systemctl', 'daemon-reload'])
         if service_resume('cdk.master.auth-webhook'):

--- a/templates/cdk.master.auth-webhook.service
+++ b/templates/cdk.master.auth-webhook.service
@@ -14,7 +14,7 @@ ExecStart={{ charm_dir }}/../.venv/bin/gunicorn \
     --keyfile /root/cdk/server.key \
     --log-level debug \
     --pid {{ pidfile }} \
-    --workers 2 \
+    --workers {{ num_workers }} \
     auth-webhook:app
 Restart=always
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1893450

Set the number of auth-webhook service workers based on the number of CPUs; set the default to the recommended value for our 2-core k8s-masters.  Also ease some of the pressure on the service by skipping the secret check if `kube-apiserver` is not active -- we can't query secrets without an active apiserver.