### PR TITLE
handle auth-webhook.log with debug-scripts

### DIFF
--- a/debug-scripts/auth-webhook
+++ b/debug-scripts/auth-webhook
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ux
+
+systemctl status cdk.master.auth-webhook.service > $DEBUG_SCRIPT_DIR/auth-webhook-systemctl-status
+
+AUTH_LOG=/root/cdk/auth-webhook/auth-webhook.log
+test -f $AUTH_LOG && cp $AUTH_LOG $DEBUG_SCRIPT_DIR


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1893682

Adds auth-webhook info to `debug-scripts` to get helpful info in our debug tarball.