### PR TITLE
ensure valid response from an external webhook service

### DIFF
--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -216,11 +216,11 @@ def forward_request(json_req, url):
         log_secret(text='Invalid response from server', obj=r.text)
         return False
 
-    # NB: When forwarding to an external URL, clobber the original request with
-    # the entire server response. This ensures any additional data that the server
-    # wants to send makes it back to the kube apiserver.
+    # NB: When a forwarded request is authenticated, set the 'status' field to
+    # whatever the external server sends us. This ensures any status fields that
+    # the server wants to send makes it back to the kube apiserver.
     if resp['status']['authenticated']:
-        json_req = resp
+        json_req['status'] = resp['status']
         return True
     return False
 


### PR DESCRIPTION
Related to https://bugs.launchpad.net/charm-kubernetes-master/+bug/1893683

We don't want to clobber the original request with an external service response; if we do, we'll lose the original dict.  Instead, we should clobber the req['status'] key to ensure we have the relevant portion of the original request as well as any 'status' data from our external service in the TokenReview object.