### PR TITLE
Make auth-webhook listen on 127.0.0.1

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -983,7 +983,7 @@ def register_auth_webhook():
     #   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18
     context = {'api_ver': 'v1beta1',
                'charm_dir': hookenv.charm_dir(),
-               'host': socket.gethostname(),
+               'host': '127.0.0.1',
                'pidfile': 'auth-webhook.pid',
                'port': 5000,
                'root_dir': auth_webhook_root}

--- a/templates/cdk.master.auth-webhook-conf.yaml
+++ b/templates/cdk.master.auth-webhook-conf.yaml
@@ -3,8 +3,8 @@ kind: Config
 clusters:
   - name: authn
     cluster:
+      certificate-authority: /root/cdk/ca.crt
       server: https://{{ host }}:{{ port }}/{{ api_ver }}
-      insecure-skip-tls-verify: true
 users:
   - name: kube-apiserver
 contexts:


### PR DESCRIPTION
Occasionally on certain clouds, `socket.gethostname()` will return a value which cannot be resolved for some reason. Since the auth-webhook tries to bind to that, it fails to start and blocks the cluster. And since it only needs to be contacted by the API server running on the same machine, this instead binds it to localhost.

Fixes [lp:1893995](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1893995)