### PR TITLE
fix webhook yaml loading; log if required server is missing

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -990,21 +990,28 @@ def register_auth_webhook():
 
     context['aws_iam_endpoint'] = None
     if endpoint_from_flag('endpoint.aws-iam.ready'):
-        if Path(aws_iam_webhook).exists():
-            aws_yaml = yaml.safe_load(aws_iam_webhook)
+        aws_webhook = Path(aws_iam_webhook)
+        if aws_webhook.exists():
+            aws_yaml = yaml.safe_load(aws_webhook.read_text())
             try:
-                context['aws_iam_endpoint'] = aws_yaml['clusters'][0]['server']
+                context['aws_iam_endpoint'] = \
+                    aws_yaml['clusters'][0]['cluster']['server']
             except (KeyError, TypeError):
+                hookenv.log(
+                    'Unable to find server in AWS IAM webhook: {}'.format(aws_yaml))
                 pass
 
     context['keystone_endpoint'] = None
     if endpoint_from_flag('keystone-credentials.available.auth'):
-        ks_webhook = keystone_root + '/webhook.yaml'
-        if Path(ks_webhook).exists():
-            ks_yaml = yaml.safe_load(ks_webhook)
+        ks_webhook = Path(keystone_root) / 'webhook.yaml'
+        if ks_webhook.exists():
+            ks_yaml = yaml.safe_load(ks_webhook.read_text())
             try:
-                context['keystone_endpoint'] = ks_yaml['clusters'][0]['server']
+                context['keystone_endpoint'] = \
+                    ks_yaml['clusters'][0]['cluster']['server']
             except (KeyError, TypeError):
+                hookenv.log(
+                    'Unable to find server in Keystone webhook: {}'.format(ks_yaml))
                 pass
 
     context['custom_authn_endpoint'] = None


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charmed-kubernetes-testing/+bug/1893824

We weren't reading the aws/keystone webhook.yaml files correctly, and even if we did, we weren't getting the right `server` key.  Verified with this change, the auth-webhook service properly ack's a keystone request:
```
[2020-09-03 16:58:12 +0000] [1268592] [DEBUG] REQ: {'kind': 'TokenReview', 'apiVersion': 'authentication.k8s.io/v1beta1', 'metadata': {'creationTimestamp': None}, 'spec': {'token': '********'}, 'status': {'user': {}}}
[2020-09-03 16:58:12 +0000] [1268592] [INFO] Checking token
[2020-09-03 16:58:12 +0000] [1268592] [INFO] Checking secret
[2020-09-03 16:58:13 +0000] [1268592] [INFO] Checking Keystone
[2020-09-03 16:58:13 +0000] [1268592] [DEBUG] Forwarding to: https://10.152.183.170:8443/webhook
[2020-09-03 16:58:13 +0000] [1268592] [DEBUG] SSLError with server; skipping cert validation
[2020-09-03 16:58:13 +0000] [1268592] [DEBUG] ACK: {'kind': 'TokenReview', 'apiVersion': 'authentication.k8s.io/v1beta1', 'metadata': {'creationTimestamp': None}, 'spec': {'token': '********'}, 'status': {'authenticated': True, 'user': {'username': 'admin', 'uid': '28f922240293487c930950efe9ec4f1e', 'groups': ['9c2d984621a44dbcb0895179ff09cd34'], 'extra': {'alpha.kubernetes.io/identity/project/id': ['9c2d984621a44dbcb0895179ff09cd34'], 'alpha.kubernetes.io/identity/project/name': ['admin'], 'alpha.kubernetes.io/identity/roles': ['Member', 'Admin'], 'alpha.kubernetes.io/identity/user/domain/id': ['3b7811b384ed445688cbc871c658471d'], 'alpha.kubernetes.io/identity/user/domain/name': ['admin_domain']}}}}
```