### PR TITLE
Fix cephfs_mounter reference error

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1390,6 +1390,7 @@ def configure_cdk_addons():
     default_storage = ''
     ceph = {}
     ceph_ep = endpoint_from_flag('ceph-storage.available')
+    cephfs_mounter = hookenv.config('cephfs-mounter')
     if (ceph_ep and ceph_ep.key() and ceph_ep.fsid() and ceph_ep.mon_hosts() and
             is_state('kubernetes-master.ceph.configured') and
             get_version('kube-apiserver') >= (1, 12)):
@@ -1400,7 +1401,6 @@ def configure_cdk_addons():
         ceph['kubernetes_key'] = b64_ceph_key.decode('ascii')
         ceph['mon_hosts'] = ceph_ep.mon_hosts()
         default_storage = hookenv.config('default-storage')
-        cephfs_mounter = hookenv.config('cephfs-mounter')
         if kubernetes_master.query_cephfs_enabled():
             cephFsEnabled = "true"
             ceph['fsname'] = kubernetes_master.get_cephfs_fsname() or ''


### PR DESCRIPTION
Related to https://bugs.launchpad.net/charm-kubernetes-master/+bug/1895352

This fixes a reference error that was introduced by https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/122:

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 74, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 390, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-master-1/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-master-1/charm/reactive/kubernetes_master.py", line 1450, in configure_cdk_addons
    'cephfs-mounter=' + cephfs_mounter,
UnboundLocalError: local variable 'cephfs_mounter' referenced before assignment
```

This PR fixes it by ensuring cephfs_mounter is always set.
