### PR TITLE
track snap revs instead of available updates when managing cohort keys

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -178,6 +178,8 @@ options:
       as possible. You may also set a custom string as described in the
       'refresh.timer' section here:
         https://forum.snapcraft.io/t/system-options/87
+
+      DEPRECATED in 1.19: Manage installed snap versions with snap-proxy.
   default-storage:
     type: string
     default: "auto"

--- a/config.yaml
+++ b/config.yaml
@@ -179,7 +179,8 @@ options:
       'refresh.timer' section here:
         https://forum.snapcraft.io/t/system-options/87
 
-      DEPRECATED in 1.19: Manage installed snap versions with snap-proxy.
+      DEPRECATED in 1.19: Manage installed snap versions with the snap-store-proxy model config.
+      See: https://snapcraft.io/snap-store-proxy and https://juju.is/docs/offline-mode-strategies#heading--snap-specific-proxy
   default-storage:
     type: string
     default: "auto"

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -433,6 +433,7 @@ def get_snap_revs(snaps):
                 d = yaml_data['channels'][channel].split()
                 snap_rev = d[2].strip("()")
             except (KeyError, IndexError):
-                hookenv.log('Could not determine revision for snap: {}'.format(s))
+                hookenv.log('Could not determine revision for snap: {}'.format(s),
+                            level=hookenv.WARNING)
         rev_info[s] = snap_rev
     return rev_info

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -406,3 +406,33 @@ def get_kubernetes_service_ips():
     '''Get the IP address(es) for the kubernetes service based on the cidr.'''
     return [next(network.hosts()).exploded
             for network in kubernetes_common.get_networks(service_cidr())]
+
+
+def get_snap_revs(snaps):
+    '''Get a dict of snap revisions for a given list of snaps.'''
+    channel = hookenv.config('channel')
+    rev_info = {}
+    for s in sorted(snaps):
+        try:
+            # valid info should looke like:
+            #  ...
+            #  channels:
+            #    latest/stable:    1.18.8         2020-08-27 (1595) 22MB classic
+            #    latest/candidate: 1.18.8         2020-08-27 (1595) 22MB classic
+            #  ...
+            info = check_output(['snap', 'info', s]).decode('utf8', errors='ignore')
+        except CalledProcessError:
+            # If 'snap info' fails for whatever reason, just empty the info
+            info = ''
+        snap_rev = None
+        yaml_data = safe_load(info)
+        if yaml_data and 'channels' in yaml_data:
+            try:
+                # valid data should look like:
+                #  ['1.18.8', '2020-08-27', '(1604)', '21MB', 'classic']
+                d = yaml_data['channels'][channel].split()
+                snap_rev = d[2].strip("()")
+            except (KeyError, IndexError):
+                hookenv.log('Could not determine revision for snap: {}'.format(s))
+        rev_info[s] = snap_rev
+    return rev_info

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -416,11 +416,13 @@ def create_or_update_cohort_keys():
         cohort_key = snap.create_cohort_snapshot(snapname)
         cohort_keys[snapname] = cohort_key
     leader_set(cohort_keys=json.dumps(cohort_keys))
-    hookenv.log('Snap cohort keys have been created.')
+    hookenv.log('Snap cohort keys have been created.', level=hookenv.INFO)
 
     # Prime revision info so we can detect changes later
     cohort_revs = kubernetes_master.get_snap_revs(cohort_snaps)
     data_changed('leader-cohort-revs', cohort_revs)
+    hookenv.log('Tracking cohort revisions: {}'.format(cohort_revs),
+                level=hookenv.DEBUG)
 
 
 @when('kubernetes-master.snaps.installed',
@@ -430,7 +432,7 @@ def check_cohort_updates():
     cohort_revs = kubernetes_master.get_snap_revs(cohort_snaps)
     if data_changed('leader-cohort-revs', cohort_revs):
         leader_set(cohort_keys=None)
-        hookenv.log('Snap cohort revisions have changed.')
+        hookenv.log('Snap cohort revisions have changed.', level=hookenv.INFO)
 
 
 @when('kubernetes-master.snaps.installed',

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -444,19 +444,9 @@ def safely_join_cohort():
     application joins the new cohort at a time. This allows us to roll out
     snap refreshes without risking all units going down at once.
     '''
-    # It's possible to join a cohort before snapd knows about the snap proxy.
-    # When this happens, we'll join a cohort, yet install default snaps. We
-    # won't refresh those until the leader keys change. Ensure we always
-    # check for available refreshes even if the leader keys haven't changed.
-    force_join = False
-    for snapname in cohort_snaps:
-        if snap.is_refresh_available(snapname):
-            force_join = True
-            break
-
     cohort_keys = leader_get('cohort_keys')
     # NB: initial data-changed is always true
-    if data_changed('leader-cohorts', cohort_keys) or force_join:
+    if data_changed('leader-cohorts', cohort_keys):
         clear_flag('kubernetes-master.cohorts.joined')
         clear_flag('kubernetes-master.cohorts.sent')
         charms.coordinator.acquire('cohort')


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1893220

We've been using `snap.is_refresh_available(snapname)` to determine when to regenerate cohort keys.  The problem with this  is that it only detects updates to installed snaps.  Since `kubelet` is not installed on `k8s-master` units, updates to that snap would not cause new keys to be created.  This left `k8s-worker` units in a state where they saw an update, but the `k8s-master` would never tell them to install it.

Fix this by tracking snap revisions (which `snap info` will tell us regardless of the installed state) instead of whether or not an update is available.

I'm also deprecating the `snapd_refresh` timer in this PR, as snap versions should be managed with a snap store proxy.