### PR TITLE
Add support for DNS provider as a charm

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -68,6 +68,8 @@ requires:
     interface: azure-integration
   keystone-credentials:
     interface: keystone-credentials
+  dns-provider:
+    interface: kube-dns
 resources:
   core:
     type: file

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1216,7 +1216,7 @@ def send_cluster_dns_detail(kube_control):
             except CalledProcessError:
                 hookenv.log("DNS addon service not ready yet")
                 return
-        kube_control.set_dns(53, dns_domain, dns_ip, dns_enabled)
+            kube_control.set_dns(53, dns_domain, dns_ip, dns_enabled)
 
 
 def create_tokens_and_sign_auth_requests():


### PR DESCRIPTION
Add support for the DNS provider (i.e., CoreDNS) to be related as a charm (e.g., one running in the cluster).

Part of [lp:1858007](https://bugs.launchpad.net/charmed-kubernetes-bundles/+bug/1858007)