### PR TITLE
Generate project scoped Keystone token for Dashboard.

### DIFF
--- a/templates/kube-keystone.sh
+++ b/templates/kube-keystone.sh
@@ -19,18 +19,27 @@ export OS_AUTH_URL="{{ protocol }}://{{ address }}:{{ port }}/v{{ version }}"
 #export OS_USERNAME=myuser
 #export OS_PASSWORD=secure_pw
 get_keystone_token() {
-  data='{ "auth": {
-    "identity": {
-      "methods": ["password"],
-      "password": {
-        "user": {
-          "name": "'"${OS_USERNAME}"'",
-          "domain": { "name": "'"${OS_DOMAIN_NAME}"'" },
-          "password": "'"${OS_PASSWORD}"'"
+  data='{
+    "auth": {
+        "identity": {
+            "methods": ["password"],
+            "password": {
+                "user": {
+                    "name": "'"${OS_USERNAME}"'",
+                    "domain": { "name": "'"${OS_DOMAIN_NAME}"'" },
+                    "password": "'"${OS_PASSWORD}"'"
+                }
+            }
+        },
+        "scope": {
+            "project": {
+                "domain": {
+                    "name": "'"${OS_DOMAIN_NAME}"'"
+                },
+                "name": "'"${OS_PROJECT_NAME}"'"
+            }
         }
-      }
     }
-  }
 }'
   token=$(curl -s -i -H "Content-Type: application/json" -d "${data}" "${OS_AUTH_URL}/auth/tokens" |grep 'X-Subject-Token')
   if [ -z "$token" ]; then
@@ -40,4 +49,3 @@ get_keystone_token() {
   fi
 }
 echo "Function get_keystone_token created. Type get_keystone_token in order to generate a login token for the Kubernetes dashboard."
-


### PR DESCRIPTION
When a user doesn't have a default project set the current kube-keystone.sh
script generates invalid tokens. This patch explicitly requests a scoped token
honouring the OS_* environment variables set.

Fixes [lp:1893214](https://pad.lv/1893214)