### PR TITLE
Temporary snap store failures shouldn't trigger new cohorts

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -431,7 +431,7 @@ def create_or_update_cohort_keys():
       'leadership.set.cohort_keys')
 def check_cohort_updates():
     cohort_revs = kubernetes_master.get_snap_revs(cohort_snaps)
-    if data_changed('leader-cohort-revs', cohort_revs):
+    if cohort_revs and data_changed('leader-cohort-revs', cohort_revs):
         leader_set(cohort_keys=None)
         hookenv.log('Snap cohort revisions have changed.', level=hookenv.INFO)
 


### PR DESCRIPTION
Small addition to [lp:1893220][] to ensure that occasional temporary request failures to the snap store (I occasionally see 503 errors) don't lead to the charms trying to create a new set of cohorts. The request error is already handled in the `get_snap_rev` function, but results in an empty dict being returned rather than the current list of revisions, which would then trigger a new cohort rollout (which might then fail due to the transient snap store errors).

[lp:1893220]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1893220