### PR TITLE
limit the number of auth-webhook worker processes

### DIFF
--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -198,12 +198,13 @@ def forward_request(json_req, url):
     Returns True if the request is authenticated; False if the response is
     either invalid or authn has been denied.
     '''
+    timeout = 10
     try:
         try:
-            r = requests.post(url, json=json_req)
+            r = requests.post(url, json=json_req, timeout=timeout)
         except requests.exceptions.SSLError:
             app.logger.debug('SSLError with server; skipping cert validation')
-            r = requests.post(url, json=json_req, verify=False)
+            r = requests.post(url, json=json_req, verify=False, timeout=timeout)
     except Exception as e:
         app.logger.debug('Failed to contact server: {}'.format(e))
         return False


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1904747

This caps our core count to 6 since more than 12ish auth-webhook workers is overkill.

Also add a timeout to external authn URLs.  If we don't get a response within 10s, consider it a failed authn.  Clients that need to auth with the apiserver will retry.