### PR TITLE
Add apiserver service-account flags for 1.20

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2094,6 +2094,8 @@ def configure_apiserver():
     api_opts['anonymous-auth'] = 'false'
     api_opts['authentication-token-webhook-cache-ttl'] = '1m0s'
     api_opts['authentication-token-webhook-config-file'] = auth_webhook_conf
+    api_opts['service-account-issuer'] = 'https://kubernetes.default.svc'
+    api_opts['service-account-signing-key-file'] = '/root/cdk/serviceaccount.key'
     api_opts['service-account-key-file'] = '/root/cdk/serviceaccount.key'
     api_opts['kubelet-preferred-address-types'] = \
         'InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP'


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1906712

Tested with channel=1.20/edge and confirmed the cluster settles and apiserver comes up. Also tested with channel=1.18/stable to confirm that this will work fine with older versions of Kubernetes.