### PR TITLE
prevent update certificates, if flags are missing

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1374,8 +1374,14 @@ def send_data():
                                    key_path=client_key_path)
 
 
-def check_flags(*flags):
-    """Check if any of the provided flags missing and return them if so."""
+def get_unset_flags(*flags):
+    """Check if any of the provided flags missing and return them if so.
+
+    :param flags: list of reactive flags
+    :type flags: non-keyword args, str
+    :returns: list of unset flags filtered from the parameters shared
+    :rtype: List[str]
+    """
     active_flags = get_flags()
     return [flag for flag in flags if flag not in active_flags]
 
@@ -1386,11 +1392,11 @@ def update_certificates():
     # NOTE: This handler may be called by another function. Two relationships
     # are required, otherwise the send_data function fails.
     # (until the relations are available)
-    missing_relations = check_flags("certificates.available",
-                                    "kube-api-endpoint.available")
+    missing_relations = get_unset_flags("certificates.available",
+                                        "kube-api-endpoint.available")
     if missing_relations:
         hookenv.log(
-            "Missing relation: '{}'".format(", ".join(missing_relations)),
+            "Missing relations: '{}'".format(", ".join(missing_relations)),
             hookenv.ERROR)
         return
 

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1377,11 +1377,16 @@ def send_data():
 @when('config.changed.extra_sans', 'certificates.available',
       'kube-api-endpoint.available')
 def update_certificates():
-    # Using the config.changed.extra_sans flag to catch changes.
-    # IP changes will take ~5 minutes or so to propagate, but
-    # it will update.
-    send_data()
-    clear_flag('config.changed.extra_sans')
+    if (is_flag_set("certificates.available") and
+            is_flag_set("kube-api-endpoint.available")):
+        # Using the config.changed.extra_sans flag to catch changes.
+        # IP changes will take ~5 minutes or so to propagate, but
+        # it will update.
+        send_data()
+        clear_flag('config.changed.extra_sans')
+    else:
+        hookenv.log("relations 'certificates' or "
+                    "'kube-api-endpoint' is missing", "ERROR")
 
 
 @when('kubernetes-master.components.started',

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -101,11 +101,11 @@ def test_service_cidr_expansion():
 
 
 @mock.patch("reactive.kubernetes_master.get_flags")
-def test_check_flags(mock_get_flags):
+def test_get_unset_flags(mock_get_flags):
     mock_get_flags.return_value = ["test.available"]
 
-    missing_flags = kubernetes_master.check_flags("test.available",
-                                                  "not-set-flag.available")
+    missing_flags = kubernetes_master.get_unset_flags("test.available",
+                                                      "not-set-flag.available")
     assert missing_flags == ["not-set-flag.available"]
 
 
@@ -118,6 +118,6 @@ def test_update_certificates_with_missing_relations(mock_send_data,
     mock_get_flags.return_value = ["test.available"]
 
     kubernetes_master.update_certificates()
-    hookenv.log.assert_any_call("Missing relation: 'certificates.available, "
+    hookenv.log.assert_any_call("Missing relations: 'certificates.available, "
                                 "kube-api-endpoint.available'", hookenv.ERROR)
     mock_send_data.assert_not_called()

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -98,3 +98,26 @@ def test_service_cidr_expansion():
     unitdata.kv().get.return_value = '10.152.0.0/16'
     update_for_service_cidr_expansion()
     assert kubectl.call_count == 4
+
+
+@mock.patch("reactive.kubernetes_master.get_flags")
+def test_check_flags(mock_get_flags):
+    mock_get_flags.return_value = ["test.available"]
+
+    missing_flags = kubernetes_master.check_flags("test.available",
+                                                  "not-set-flag.available")
+    assert missing_flags == ["not-set-flag.available"]
+
+
+@mock.patch("reactive.kubernetes_master.get_flags")
+@mock.patch("reactive.kubernetes_master.send_data")
+def test_update_certificates_with_missing_relations(mock_send_data,
+                                                    mock_get_flags):
+    # NOTE (rgildein): This test only tests whether the send_data function
+    # has been called, if required relations are missing.
+    mock_get_flags.return_value = ["test.available"]
+
+    kubernetes_master.update_certificates()
+    hookenv.log.assert_any_call("Missing relation: 'certificates.available, "
+                                "kube-api-endpoint.available'", hookenv.ERROR)
+    mock_send_data.assert_not_called()


### PR DESCRIPTION
If "kube-api-endpoint" relationships are not set, the "send_data"
function run by "update_certificates" will failed.
Added a condition to prevent this from happening.

Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1836063