### PR TITLE
Set blocked state if CA is missing

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -703,11 +703,6 @@ def set_app_version():
     hookenv.application_version_set(version.split(b' v')[-1].rstrip())
 
 
-@when_not('certificates.available')
-def missing_certificates_notice():
-    hookenv.status_set('blocked', 'Missing relation to certificate authority.')
-
-
 @hookenv.atstart
 def check_vault_pending():
     try:
@@ -736,6 +731,11 @@ def set_final_status():
         hookenv.status_set('blocked',
                            'Series upgrade in progress')
         return
+
+    if not is_flag_set('certificates.available'):
+        hookenv.status_set('blocked', 'Missing relation to certificate authority.')
+        return
+
     if is_flag_set('kubernetes-master.secure-storage.failed'):
         hookenv.status_set('blocked',
                            'Failed to configure encryption; '
@@ -896,10 +896,6 @@ def set_final_status():
     if is_leader and ks and \
        not is_flag_set('kubernetes-master.keystone-policy-handled'):
         hookenv.status_set('waiting', 'Waiting to apply keystone policy file.')
-        return
-
-    if not is_flag_set('certificates.available'):
-        missing_certificates_notice()
         return
 
     hookenv.status_set('active', 'Kubernetes master running.')

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -703,6 +703,11 @@ def set_app_version():
     hookenv.application_version_set(version.split(b' v')[-1].rstrip())
 
 
+@when_not('certificates.available')
+def missing_certificates_notice():
+    hookenv.status_set('blocked', 'Missing relation to certificate authority.')
+
+
 @hookenv.atstart
 def check_vault_pending():
     try:
@@ -891,6 +896,10 @@ def set_final_status():
     if is_leader and ks and \
        not is_flag_set('kubernetes-master.keystone-policy-handled'):
         hookenv.status_set('waiting', 'Waiting to apply keystone policy file.')
+        return
+
+    if not is_flag_set('certificates.available'):
+        missing_certificates_notice()
         return
 
     hookenv.status_set('active', 'Kubernetes master running.')

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -100,14 +100,6 @@ def test_service_cidr_expansion():
     assert kubectl.call_count == 4
 
 
-def test_get_unset_flags():
-    set_flag("test.available")
-
-    missing_flags = kubernetes_master.get_unset_flags("test.available",
-                                                      "not-set-flag.available")
-    assert missing_flags == ["not-set-flag.available"]
-
-
 @mock.patch("reactive.kubernetes_master.send_data")
 def test_update_certificates_with_missing_relations(mock_send_data):
     # NOTE (rgildein): This test only tests whether the send_data function

--- a/tests/test_kubernetes_master.py
+++ b/tests/test_kubernetes_master.py
@@ -100,22 +100,19 @@ def test_service_cidr_expansion():
     assert kubectl.call_count == 4
 
 
-@mock.patch("reactive.kubernetes_master.get_flags")
-def test_get_unset_flags(mock_get_flags):
-    mock_get_flags.return_value = ["test.available"]
+def test_get_unset_flags():
+    set_flag("test.available")
 
     missing_flags = kubernetes_master.get_unset_flags("test.available",
                                                       "not-set-flag.available")
     assert missing_flags == ["not-set-flag.available"]
 
 
-@mock.patch("reactive.kubernetes_master.get_flags")
 @mock.patch("reactive.kubernetes_master.send_data")
-def test_update_certificates_with_missing_relations(mock_send_data,
-                                                    mock_get_flags):
+def test_update_certificates_with_missing_relations(mock_send_data):
     # NOTE (rgildein): This test only tests whether the send_data function
     # has been called, if required relations are missing.
-    mock_get_flags.return_value = ["test.available"]
+    set_flag('test_available')
 
     kubernetes_master.update_certificates()
     hookenv.log.assert_any_call("Missing relations: 'certificates.available, "
@@ -123,21 +120,16 @@ def test_update_certificates_with_missing_relations(mock_send_data,
     mock_send_data.assert_not_called()
 
 
-@mock.patch("reactive.kubernetes_master.is_flag_set")
-@mock.patch("reactive.kubernetes_master.hookenv.status_set")
-def test_status_set_on_missing_ca(mock_status_set, mock_is_flag_set):
+def test_status_set_on_missing_ca():
     """Test that set_final_status() will set blocked state if CA is missing"""
-    def is_flag_set_side_effect(flag):
-        flags = {'upgrade.series.in-progress': False,
-                 'certificates.available': False}
-        value = flags.get(flag, None)
-        assert value is not None, "Unexpected flag requested: {}".format(flag)
-        return value
-
-    mock_is_flag_set.side_effect = is_flag_set_side_effect
-
+    set_flag("certificates.available")
+    set_flag("kubernetes-master.secure-storage.failed")
     kubernetes_master.set_final_status()
-
-    mock_status_set.assert_called_once_with('blocked',
-                                            'Missing relation to certificate '
-                                            'authority.')
+    hookenv.status_set.assert_called_with('blocked',
+                                          'Failed to configure encryption; '
+                                          'secrets are unencrypted or inaccessible')
+    clear_flag("certificates.available")
+    kubernetes_master.set_final_status()
+    hookenv.status_set.assert_called_with('blocked',
+                                          'Missing relation to certificate '
+                                          'authority.')


### PR DESCRIPTION
I took a same approach as  [etcd charm](https://github.com/charmed-kubernetes/layer-etcd/blob/39154a235f7e6996b94d069938752c98055d0f65/reactive/etcd.py#L128) and added check for missing `certificates.available` flag.

I have the same thing prepared for the kubernetes-worker, but I'm gonna open this PR first to hammer out any possible issues.

LP: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1868541