### PR TITLE
ensure secret names are unique and rfc1123 compliant

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -63,7 +63,9 @@ user-create:
   params:
     name:
       type: string
-      description: Username for the new user
+      description: |
+        Username for the new user. This value must only contain alphanumeric
+        characters, '@', '-' or '.'.
       minLength: 2
     groups:
       type: string

--- a/actions/user_actions.py
+++ b/actions/user_actions.py
@@ -66,7 +66,9 @@ def user_create():
     # TODO: make the token format less magical so it doesn't get out of
     # sync with the function that creates secrets in k8s-master.py.
     token = '{}::{}'.format(user, layer.kubernetes_master.token_generator())
-    layer.kubernetes_master.create_secret(token, user, user, groups)
+    if not layer.kubernetes_master.create_secret(token, user, user, groups):
+        action_fail('Failed to create secret for: {}'.format(user))
+        return
 
     # Create a kubeconfig
     ca_crt = layer.kubernetes_common.ca_crt_path

--- a/actions/user_actions.py
+++ b/actions/user_actions.py
@@ -1,6 +1,7 @@
 #!/usr/local/sbin/charm-env python3
 import json
 import os
+import re
 import sys
 from base64 import b64decode
 from charmhelpers.core import hookenv
@@ -60,6 +61,12 @@ def user_create():
     users = user_list()
     if user in list(users):
         action_fail('User "{}" already exists.'.format(user))
+        return
+
+    # Validate the name
+    if re.search('[^0-9A-Za-z@.-]+', user):
+        msg = "User name may only contain alphanumeric characters, '@', '-' or '.'"
+        action_fail(msg)
         return
 
     # Create the secret

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -247,8 +247,8 @@ def create_known_token(token, username, user, groups=None):
 
 def create_secret(token, username, user, groups=None):
     # secret IDs must be unique and rfc1123 compliant
-    uniq_name = re.sub('[^0-9a-z.-]+', '-', user.lower())
-    secret_id = '{}-{}-{}'.format(uniq_name, generate_rfc1123(10), AUTH_SECRET_SUFFIX)
+    sani_name = re.sub('[^0-9a-z.-]+', '-', user.lower())
+    secret_id = '{}-{}-{}'.format(sani_name, generate_rfc1123(10), AUTH_SECRET_SUFFIX)
     # The authenticator expects tokens to be in the form user::token
     token_delim = '::'
     if token_delim not in token:

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -247,8 +247,8 @@ def create_known_token(token, username, user, groups=None):
 
 def create_secret(token, username, user, groups=None):
     # secret IDs must be unique and rfc1123 compliant
-    uniq_name = re.sub('[^0-9a-z.-]+', '-', user.lower()) + generate_rfc1123(10)
-    secret_id = '{}-{}'.format(uniq_name, AUTH_SECRET_SUFFIX)
+    uniq_name = re.sub('[^0-9a-z.-]+', '-', user.lower())
+    secret_id = '{}-{}-{}'.format(uniq_name, generate_rfc1123(10), AUTH_SECRET_SUFFIX)
     # The authenticator expects tokens to be in the form user::token
     token_delim = '::'
     if token_delim not in token:

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -22,7 +22,6 @@ from charms.layer import kubernetes_common
 AUTH_BACKUP_EXT = 'pre-secrets'
 AUTH_BASIC_FILE = '/root/cdk/basic_auth.csv'
 AUTH_SECRET_NS = 'kube-system'
-AUTH_SECRET_SUFFIX = 'token-auth'
 AUTH_SECRET_TYPE = 'juju.is/token-auth'
 AUTH_TOKENS_FILE = '/root/cdk/known_tokens.csv'
 STANDARD_API_PORT = 6443
@@ -257,7 +256,7 @@ def create_known_token(token, username, user, groups=None):
 def create_secret(token, username, user, groups=None):
     # secret IDs must be unique and rfc1123 compliant
     sani_name = re.sub('[^0-9a-z.-]+', '-', user.lower())
-    secret_id = '{}-{}-{}'.format(sani_name, generate_rfc1123(10), AUTH_SECRET_SUFFIX)
+    secret_id = 'auth-{}-{}'.format(sani_name, generate_rfc1123(10))
     # The authenticator expects tokens to be in the form user::token
     token_delim = '::'
     if token_delim not in token:

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -198,8 +198,17 @@ def generate_rfc1123(length=10):
     param: length - the length of the string to generate
     '''
     length = 253 if length > 253 else length
-    options = string.ascii_lowercase + string.digits + '-' + '.'
-    return ''.join(random.SystemRandom().choice(options) for _ in range(length))
+    first_last_opts = string.ascii_lowercase + string.digits
+    middle_opts = first_last_opts + '-' + '.'
+
+    # ensure first and last chars are alphanum
+    length -= 2
+    rand_str = (
+        random.SystemRandom().choice(first_last_opts) +
+        ''.join(random.SystemRandom().choice(middle_opts) for _ in range(length)) +
+        random.SystemRandom().choice(first_last_opts)
+    )
+    return rand_str
 
 
 def token_generator(length=32):

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -247,7 +247,7 @@ def create_known_token(token, username, user, groups=None):
 
 def create_secret(token, username, user, groups=None):
     # secret IDs must be unique and rfc1123 compliant
-    uniq_name = re.sub('[^0-9a-z]+', '-', user.lower()) + generate_rfc1123(10)
+    uniq_name = re.sub('[^0-9a-z.-]+', '-', user.lower()) + generate_rfc1123(10)
     secret_id = '{}-{}'.format(uniq_name, AUTH_SECRET_SUFFIX)
     # The authenticator expects tokens to be in the form user::token
     token_delim = '::'

--- a/tests/test_kubernetes_master_actions.py
+++ b/tests/test_kubernetes_master_actions.py
@@ -54,6 +54,13 @@ def test_user_create(mock_get, mock_master, mock_common, mock_chmod):
         user_actions.user_create()
         assert user_actions.action_fail.called
 
+    # Ensure failure when user name is invalid
+    mock_get.return_value = 'FunnyBu;sness'
+    with mock.patch('actions.user_actions.user_list',
+                    return_value=test_data):
+        user_actions.user_create()
+        assert user_actions.action_fail.called
+
     # Ensure calls/args when we have a new user
     user = 'newuser'
     password = 'password'

--- a/tests/test_kubernetes_master_lib.py
+++ b/tests/test_kubernetes_master_lib.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import pytest
+import re
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -72,6 +73,12 @@ def test_delete_secret(mock_kubectl):
     assert charmlib.delete_secret('secret-id')
     args, kwargs = mock_kubectl.call_args
     assert secret_ns in args
+
+
+def test_generate_rfc1123():
+    """Verify genereated string is RFC 1123 compliant."""
+    id = charmlib.generate_rfc1123()
+    assert re.sub('[^0-9a-z.-]+', '-', id) == id
 
 
 def test_get_csv_password(auth_file):

--- a/tests/test_kubernetes_master_lib.py
+++ b/tests/test_kubernetes_master_lib.py
@@ -78,7 +78,7 @@ def test_delete_secret(mock_kubectl):
 def test_generate_rfc1123():
     """Verify genereated string is RFC 1123 compliant."""
     id = charmlib.generate_rfc1123()
-    assert re.sub('[^0-9a-z.-]+', '-', id) == id
+    assert re.search('[^0-9a-z.-]+', id) is None
 
 
 def test_get_csv_password(auth_file):


### PR DESCRIPTION
Add a random string to the generated secret names to ensure they are unique for a cluster.  Names also need to be rfc1123 compliant:

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

Fixes [LP 1911445](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1911445)