### PR TITLE
Finalize up-port of get_unset_flags helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ make charm
 tox
 ```
 
-Note that the unit tests use [`charms.unit_test`][https://pypi.org/project/charms.unit-test/]
+Note that the unit tests use [`charms.unit_test`](https://pypi.org/project/charms.unit-test/)
 so all charms.reactive helpers are automatically patched with fakes, so little manual
 patching needs to be done and things like `set_flag` and `is_flag_set` can be used directly.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ For details on configuring and operating this charm, see the [kubernetes-master 
 ```
 make charm
 ```
+
+## Testing the charm
+
+```
+tox
+```
+
+Note that the unit tests use [`charms.unit_test`][https://pypi.org/project/charms.unit-test/]
+so all charms.reactive helpers are automatically patched with fakes, so little manual
+patching needs to be done and things like `set_flag` and `is_flag_set` can be used directly.

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ tox
 ```
 
 Note that the unit tests use [`charms.unit_test`](https://pypi.org/project/charms.unit-test/)
-so all charms.reactive helpers are automatically patched with fakes, so little manual
-patching needs to be done and things like `set_flag` and `is_flag_set` can be used directly.
+so all charms.reactive helpers are automatically patched with fakes and little manual
+patching needs to be done. Things like `set_flag` and `is_flag_set` can be used directly.

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -37,7 +37,7 @@ from charms.leadership import leader_get, leader_set
 from charms.reactive import hook
 from charms.reactive import remove_state, clear_flag
 from charms.reactive import set_state, set_flag
-from charms.reactive import is_state, is_flag_set, get_flags, all_flags_set
+from charms.reactive import is_state, is_flag_set, get_unset_flags, all_flags_set
 from charms.reactive import endpoint_from_flag
 from charms.reactive import when, when_any, when_not, when_none
 from charms.reactive import register_trigger
@@ -1377,18 +1377,6 @@ def send_data():
     tls_client.request_client_cert('system:kube-apiserver',
                                    crt_path=client_crt_path,
                                    key_path=client_key_path)
-
-
-def get_unset_flags(*flags):
-    """Check if any of the provided flags missing and return them if so.
-
-    :param flags: list of reactive flags
-    :type flags: non-keyword args, str
-    :returns: list of unset flags filtered from the parameters shared
-    :rtype: List[str]
-    """
-    active_flags = get_flags()
-    return [flag for flag in flags if flag not in active_flags]
 
 
 @when('config.changed.extra_sans', 'certificates.available',


### PR DESCRIPTION
The `get_unset_flags` helpers was [up-ported to charms.reactive][pr_228] and the test for the helpers was removed in #136, so we should use the upstream version instead.

[pr_228]: https://github.com/juju-solutions/charms.reactive/pull/228