### PR TITLE
reuse existing secret names and make secret UIDs more useful

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -65,7 +65,7 @@ user-create:
       type: string
       description: |
         Username for the new user. This value must only contain alphanumeric
-        characters, '@', '-' or '.'.
+        characters, ':', '@', '-' or '.'.
       minLength: 2
     groups:
       type: string

--- a/actions/user_actions.py
+++ b/actions/user_actions.py
@@ -64,8 +64,8 @@ def user_create():
         return
 
     # Validate the name
-    if re.search('[^0-9A-Za-z@.-]+', user):
-        msg = "User name may only contain alphanumeric characters, '@', '-' or '.'"
+    if re.search('[^0-9A-Za-z:@.-]+', user):
+        msg = "User name may only contain alphanumeric characters, ':', '@', '-' or '.'"
         action_fail(msg)
         return
 

--- a/actions/user_actions.py
+++ b/actions/user_actions.py
@@ -1,9 +1,7 @@
 #!/usr/local/sbin/charm-env python3
-import json
 import os
 import re
 import sys
-from base64 import b64decode
 from charmhelpers.core import hookenv
 from charmhelpers.core.hookenv import (
     action_get,
@@ -34,23 +32,9 @@ def protect_resources(name):
 
 def user_list():
     '''Return a dict of 'username: secret_id' for Charmed Kubernetes users.'''
-    output = layer.kubernetes_common.kubectl(
-        'get', 'secrets', '-n', layer.kubernetes_master.AUTH_SECRET_NS,
-        '--field-selector', 'type={}'.format(layer.kubernetes_master.AUTH_SECRET_TYPE),
-        '-o', 'json').decode('UTF-8')
-    secrets = json.loads(output)
-    users = {}
-    if 'items' in secrets:
-        for secret in secrets['items']:
-            try:
-                secret_id = secret['metadata']['name']
-                username_b64 = secret['data']['username'].encode('UTF-8')
-            except (KeyError, TypeError):
-                # CK secrets will have populated 'data', but not all secrets do
-                continue
-            users[b64decode(username_b64).decode('UTF-8')] = secret_id
-    action_set({'users': ', '.join(list(users))})
-    return users
+    secrets = layer.kubernetes_master.get_secret_names()
+    action_set({'users': ', '.join(list(secrets))})
+    return secrets
 
 
 def user_create():

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -325,6 +325,7 @@ def get_secret_names():
     except (CalledProcessError, FileNotFoundError):
         # The api server may not be up, or we may be trying to run kubelet before
         # the snap is installed. Send back an empty dict.
+        hookenv.log('Unable to get existing secrets', level=hookenv.WARNING)
         return {}
 
     secrets = json.loads(output)

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -254,9 +254,15 @@ def create_known_token(token, username, user, groups=None):
 
 
 def create_secret(token, username, user, groups=None):
-    # secret IDs must be unique and rfc1123 compliant
-    sani_name = re.sub('[^0-9a-z.-]+', '-', user.lower())
-    secret_id = 'auth-{}-{}'.format(sani_name, generate_rfc1123(10))
+    secrets = get_secret_names()
+    if username in secrets:
+        # Use existing secret ID if one exists for our username
+        secret_id = secrets[username]
+    else:
+        # secret IDs must be unique and rfc1123 compliant
+        sani_name = re.sub('[^0-9a-z.-]+', '-', user.lower())
+        secret_id = 'auth-{}-{}'.format(sani_name, generate_rfc1123(10))
+
     # The authenticator expects tokens to be in the form user::token
     token_delim = '::'
     if token_delim not in token:
@@ -307,6 +313,32 @@ def get_csv_password(csv_fname, user):
                 # probably a blank line or comment; move on
                 continue
     return None
+
+
+def get_secret_names():
+    '''Return a dict of 'username: secret_id' for Charmed Kubernetes users.'''
+    try:
+        output = kubernetes_common.kubectl(
+            'get', 'secrets', '-n', AUTH_SECRET_NS,
+            '--field-selector', 'type={}'.format(AUTH_SECRET_TYPE),
+            '-o', 'json').decode('UTF-8')
+    except (CalledProcessError, FileNotFoundError):
+        # The api server may not be up, or we may be trying to run kubelet before
+        # the snap is installed. Send back an empty dict.
+        return {}
+
+    secrets = json.loads(output)
+    secret_names = {}
+    if 'items' in secrets:
+        for secret in secrets['items']:
+            try:
+                secret_id = secret['metadata']['name']
+                username_b64 = secret['data']['username'].encode('UTF-8')
+            except (KeyError, TypeError):
+                # CK secrets will have populated 'data', but not all secrets do
+                continue
+            secret_names[b64decode(username_b64).decode('UTF-8')] = secret_id
+    return secret_names
 
 
 def get_secret_password(username):

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1289,8 +1289,10 @@ def create_tokens_and_sign_auth_requests():
             continue
         kubelet_token = get_token(username)
         if not kubelet_token:
-            # Usernames have to be in the form of system:node:<nodeName>
-            userid = "kubelet-{}".format(request[0].split('/')[1])
+            # Username will be in the form of system:node:<nodeName>.
+            # User ID will be a worker <unitName>, and while not used today, we store
+            # this in case it becomes useful to map a secret to a unit in the future.
+            userid = request[0]
             setup_tokens(None, username, userid, group)
             kubelet_token = get_token(username)
         # When bootstrapping a new cluster, we may not have all our secrets yet.

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -145,7 +145,7 @@ def check_secrets(token_review):
                 username = uid = b64decode(username_b64).decode('UTF-8')
                 pw_delim = '::'
                 if pw_delim in password:
-                    uid = password.split(pw_delim)[0]
+                    uid = password.rsplit(pw_delim, 1)[0]
                 groups = b64decode(groups_b64).decode('UTF-8').split(',')
                 token_review['status'] = {
                     'authenticated': True,

--- a/tests/test_kubernetes_master_lib.py
+++ b/tests/test_kubernetes_master_lib.py
@@ -102,6 +102,29 @@ def test_get_csv_password(auth_file):
     assert charmlib.get_csv_password(auth_file, user) == password
 
 
+def test_get_secret_names():
+    """Verify expected {username: secret_id} dict is returned."""
+    secret = 'mine'
+    user = 'admin'
+
+    test_data = {
+        'items': [{
+            'data': {
+                'username': base64.b64encode(user.encode('utf-8')).decode('utf-8'),
+            },
+            'metadata': {
+                'name': secret,
+            }
+        }]
+    }
+    secrets = json.dumps(test_data).encode('utf-8')
+
+    # valid user should return a valid secret
+    with mock.patch('lib.charms.layer.kubernetes_master.kubernetes_common.kubectl',
+                    return_value=secrets):
+        assert charmlib.get_secret_names()[user] == secret
+
+
 def test_get_secret_password():
     """Verify expected secret token is returned."""
     password = 'password'

--- a/tests/test_kubernetes_master_lib.py
+++ b/tests/test_kubernetes_master_lib.py
@@ -46,7 +46,9 @@ def test_migrate_auth_file(auth_file):
 @mock.patch('lib.charms.layer.kubernetes_master.render')
 @mock.patch('lib.charms.layer.kubernetes_master.kubernetes_common.kubectl_manifest',
             return_value=True)
-def test_create_secret(mock_kubectl, mock_render):
+@mock.patch('lib.charms.layer.kubernetes_master.get_secret_names',
+            return_value={})
+def test_create_secret(mock_secrets, mock_kubectl, mock_render):
     """Verify valid secret data is sent to kubectl during create."""
     password = 'password'
     user_id = 'replace$uid'


### PR DESCRIPTION
If a secret exists for a user/service, reuse that name to ensure users/services don't have multiple secrets at once. This is needed since #138 introduced random strings in secret names to make them unique, hence we can no longer easily construct a secret name based on the user/service alone.

With reusable unique secret names, we are free to make the uid field more accurate -- instead of `kubelet-0`, we'll use `kubernetes-worker-0`.  This makes it easy for an admin to spot which secret belongs to which unit, and becomes especially useful when, for example, `k8s-worker` is deployed multiple times with different application names.

While we're here, allow `:` in usernames when creating new users. We have services like `system:node:foo` that show up in our user list, but had previously not allowed `:` when running the `user-create` action. This could be confusing, and there's no reason to disallow that character, so stop doing that.

Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1906732