### PR TITLE
add kubeconfig to kubectl commands in actions

### DIFF
--- a/actions/namespace-create
+++ b/actions/namespace-create
@@ -15,7 +15,8 @@ os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
 
 def kubectl(args):
-    cmd = ['kubectl'] + args
+    cmd = ["kubectl", "--kubeconfig=/home/ubuntu/config"]
+    cmd.extend(args)
     return check_output(cmd)
 
 


### PR DESCRIPTION
Following actions namespace-create, namespace-list, namespace-delete
run kubectl command without kubeconfig parameter. This is required
since the HOME environment variable is not set, so no default
kubeconfig file is picked.

Add -kubeconfig=/home/ubuntu/config to kubectl command

Closes-Bug: #1914359