### PR TITLE
Fix the NetworkUnavailable workaround

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2658,7 +2658,7 @@ def poke_network_unavailable():
     http_header = ("Authorization", "Bearer {}".format(client_token))
 
     try:
-        output = kubectl("kubectl", "get", "nodes", "-o", "json").decode("utf-8")
+        output = kubectl("get", "nodes", "-o", "json").decode("utf-8")
         nodes = json.loads(output)["items"]
     except CalledProcessError:
         hookenv.log("failed to get kube-system nodes")

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2654,13 +2654,11 @@ def poke_network_unavailable():
     local_address = get_ingress_address("kube-api-endpoint")
     local_server = "https://{0}:{1}".format(local_address, 6443)
 
-    cmd = ["kubectl", "get", "nodes", "-o", "json"]
-
     client_token = get_token("admin")
     http_header = ("Authorization", "Bearer {}".format(client_token))
 
     try:
-        output = check_output(cmd).decode("utf-8")
+        output = kubectl("kubectl", "get", "nodes", "-o", "json").decode("utf-8")
         nodes = json.loads(output)["items"]
     except CalledProcessError:
         hookenv.log("failed to get kube-system nodes")


### PR DESCRIPTION
The upstream change in 1.18 to disable the implicit local API endpoint meant that all calls to `kubectl` need the explicit config. Apparently, we missed one in the `poke_network` workaround for cloud-providers which don't properly manage the flag (e.g., GCP).

Fixes [lp:1907088][]

[lp:1907088]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1907088