### PR TITLE
Refactor integration test to align with pytest-operator changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.pyc
 placeholders/
+*.charm

--- a/tests/integration/test_kubernetes_master_integration.py
+++ b/tests/integration/test_kubernetes_master_integration.py
@@ -1,25 +1,26 @@
 import logging
 
-from pytest_operator import OperatorTest
+import pytest
 
 
 log = logging.getLogger(__name__)
 
 
-class KubernetesMasterIntegrationTest(OperatorTest):
-    async def test_build_and_deploy(self):
-        bundle = self.render_bundle(
-            "tests/data/bundle.yaml", master_charm=await self.build_charm(".")
-        )
-        await self.model.deploy(bundle)
-        await self.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test):
+    bundle = ops_test.render_bundle(
+        "tests/data/bundle.yaml", master_charm=await ops_test.build_charm(".")
+    )
+    await ops_test.model.deploy(bundle)
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
 
-    async def test_status_messages(self):
-        """ Validate that the status messages are correct. """
-        expected_messages = {
-            "kubernetes-master": "Kubernetes master running.",
-            "kubernetes-worker": "Kubernetes worker running.",
-        }
-        for app, message in expected_messages.items():
-            for unit in self.model.applications[app].units:
-                assert unit.workload_status_message == message
+
+async def test_status_messages(ops_test):
+    """ Validate that the status messages are correct. """
+    expected_messages = {
+        "kubernetes-master": "Kubernetes master running.",
+        "kubernetes-worker": "Kubernetes worker running.",
+    }
+    for app, message in expected_messages.items():
+        for unit in ops_test.model.applications[app].units:
+            assert unit.workload_status_message == message

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ deps =
     # Until 2.8.6 is released
     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
+    # Until PR #10 lands
+    https://github.com/charmed-kubernetes/pytest-operator/archive/johnsca/remove-unittest.zip#egg=pytest-operator
     pytest-operator
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,6 @@ deps =
     # Until 2.8.6 is released
     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
-    # Until PR #10 lands
-    https://github.com/charmed-kubernetes/pytest-operator/archive/johnsca/remove-unittest.zip#egg=pytest-operator
     pytest-operator
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 


### PR DESCRIPTION
Changes to the integration test to align with the changes to pytest-operator in [PR #10][].

[PR #10]: https://github.com/charmed-kubernetes/pytest-operator/pull/10