### PR TITLE
Fix token creation naming and retry logic

### DIFF
--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -197,16 +197,8 @@ def generate_rfc1123(length=10):
     param: length - the length of the string to generate
     """
     length = 253 if length > 253 else length
-    first_last_opts = string.ascii_lowercase + string.digits
-    middle_opts = first_last_opts + "-" + "."
-
-    # ensure first and last chars are alphanum
-    length -= 2
-    rand_str = (
-        random.SystemRandom().choice(first_last_opts)
-        + "".join(random.SystemRandom().choice(middle_opts) for _ in range(length))
-        + random.SystemRandom().choice(first_last_opts)
-    )
+    valid_chars = string.ascii_lowercase + string.digits
+    rand_str = "".join(random.SystemRandom().choice(valid_chars) for _ in range(length))
     return rand_str
 
 

--- a/tests/unit/test_kubernetes_master_lib.py
+++ b/tests/unit/test_kubernetes_master_lib.py
@@ -83,7 +83,7 @@ def test_delete_secret(mock_kubectl):
 def test_generate_rfc1123():
     """Verify genereated string is RFC 1123 compliant."""
     id = charmlib.generate_rfc1123()
-    assert re.search("[^0-9a-z.-]+", id) is None
+    assert re.search("[^0-9a-z]+", id) is None
 
 
 def test_get_csv_password(auth_file):

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     pyyaml
     pytest
     charms.unit_test
+    ipdb
 commands = pytest --tb native -s {posargs} {toxinidir}/tests/unit
 
 [testenv:integration]
@@ -23,6 +24,7 @@ deps =
     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
     pytest-operator
+    ipdb
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:lint]


### PR DESCRIPTION
Avoid the possibility of invalid runs of dashes or dots in token names by removing them from the list of characters. Also ensure that failed token creation is actually retried and report such failures in status.

Fixes [lp:1916780][]

[lp:1916780]: https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1916780