### PR TITLE
update audit apiversion to v1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ options:
   audit-policy:
     type: string
     default: |
-      apiVersion: audit.k8s.io/v1beta1
+      apiVersion: audit.k8s.io/v1
       kind: Policy
       rules:
       # Don't log read-only requests from the apiserver


### PR DESCRIPTION
`audit.k8s.io/v1beta1` is [deprecated in 1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#deprecation) in favor of `audit.k8s.io/v1`. Update k8s-master config accordingly.

Fixes https://bugs.launchpad.net/charm-kubernetes-master/+bug/1921435