### PR TITLE
Bump k8s channel to 1.21/stable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.20/stable"
+    default: "1.21/stable"
     description: |
       Snap channel to install Kubernetes master services from
   client_password:

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -41,7 +41,7 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.20/stable
+      channel: 1.21/stable
     resources:
       cdk-addons: 0
       core: 0
@@ -58,7 +58,7 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.20/stable
+      channel: 1.21/stable
     resources:
       cni-amd64: 690
       cni-arm64: 681


### PR DESCRIPTION
For the CK 1.21 RC release. The stable branches have already been reset to master, therefore, this PR is targeted against stable.