### PR TITLE
Add support for loadbalancer interface

### DIFF
--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -74,10 +74,12 @@ def get_internal_api_endpoints(relation=None):
 
     # If the internal LB relation is attached, use that or nothing. If it's
     # not attached but the external LB relation is, use that or nothing.
-    for lb_endpoint in ("loadbalancer-internal", "loadbalancer-external"):
+    for lb_type in ("internal", "external"):
+        lb_endpoint = "loadbalancer-" + lb_type
+        request_name = "api-server-" + lb_type
         if lb_endpoint in goal_state["relations"]:
             lb_provider = endpoint_from_name(lb_endpoint)
-            lb_response = lb_provider.get_response("kube-api")
+            lb_response = lb_provider.get_response(request_name)
             if not lb_response or lb_response.error:
                 return []
             return [(lb_response.address, STANDARD_API_PORT)]
@@ -150,6 +152,8 @@ def get_api_url(endpoints):
     """
     Choose an API endpoint from the list and build a URL from it.
     """
+    if not endpoints:
+        return None
     urls = get_api_urls(endpoints)
     return urls[kubernetes_common.get_unit_number() % len(urls)]
 

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -15,7 +15,7 @@ from charmhelpers.core import hookenv
 from charmhelpers.core.templating import render
 from charmhelpers.core import unitdata
 from charmhelpers.fetch import apt_install
-from charms.reactive import endpoint_from_flag, is_flag_set
+from charms.reactive import endpoint_from_flag, endpoint_from_name, is_flag_set
 from charms.layer import kubernetes_common
 
 
@@ -60,10 +60,14 @@ def get_lb_endpoints():
     relation.
     """
     external_lb_endpoints = get_external_lb_endpoints()
+    lb_provider = endpoint_from_name("lb-provider")
+    lb_response = lb_provider.get_response("api-server")
     loadbalancer = endpoint_from_flag("loadbalancer.available")
 
     if external_lb_endpoints:
         return external_lb_endpoints
+    elif lb_response and lb_response.address:
+        return [(lb_response.address, STANDARD_API_PORT)]
     elif loadbalancer:
         lb_addresses = loadbalancer.get_addresses_ports()
         return [(host.get("public-address"), host.get("port")) for host in lb_addresses]

--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -86,7 +86,7 @@ def get_internal_api_endpoints(relation=None):
 
     # Support the older loadbalancer relation (public-address interface).
     if "loadbalancer" in goal_state["relations"]:
-        loadbalancer = endpoint_from_flag("loadbalancer.available")
+        loadbalancer = endpoint_from_name("loadbalancer")
         lb_addresses = loadbalancer.get_addresses_ports()
         return [(host.get("public-address"), host.get("port")) for host in lb_addresses]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,9 +29,13 @@ peers:
     interface: kube-masters
 provides:
   kube-api-endpoint:
-    # kube-api-endpoint is deprecated. Its functionality has been rolled into
-    # the kube-control interface. The relation endpoint will be removed in a
-    # future release.
+    # Use of this relation is strongly discouraged as the API endpoints will be
+    # provided via the kube-control relation. However, it can be used to
+    # override those endpoints if you need to inject a reverse proxy between
+    # the master and workers using a charm which only supports the old MITM
+    # style relations. Note, though, that since this reverse proxy will not be
+    # visible to the master, it will not be used in any of the client or
+    # component kube config files.
     interface: http
   cluster-dns:
     # kube-dns is deprecated. Its functionality has been rolled into the
@@ -54,6 +58,8 @@ requires:
   etcd:
     interface: etcd
   loadbalancer:
+    # Use of this relation is strongly discouraged in favor of the more
+    # explicit loadbalancer-internal / loadbalancer-external relations.
     interface: public-address
   ceph-storage:
     interface: ceph-admin
@@ -73,7 +79,13 @@ requires:
     interface: keystone-credentials
   dns-provider:
     interface: kube-dns
-  lb-provider:
+  loadbalancer-internal:
+    # Indicates that the LB should not be public and should use internal
+    # networks if available. Intended for control plane and other internal use.
+    interface: loadbalancer
+  loadbalancer-external:
+    # Indicates that the LB should be public facing. Intended for clients which
+    # must reach the API server via external networks.
     interface: loadbalancer
 resources:
   core:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,6 +29,9 @@ peers:
     interface: kube-masters
 provides:
   kube-api-endpoint:
+    # kube-api-endpoint is deprecated. Its functionality has been rolled into
+    # the kube-control interface. The relation endpoint will be removed in a
+    # future release.
     interface: http
   cluster-dns:
     # kube-dns is deprecated. Its functionality has been rolled into the
@@ -70,6 +73,8 @@ requires:
     interface: keystone-credentials
   dns-provider:
     interface: kube-dns
+  lb-provider:
+    interface: loadbalancer
 resources:
   core:
     type: file

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1449,6 +1449,10 @@ def request_load_balancer():
 @when("kube-control.connected")
 def send_api_endpoints():
     kube_control = endpoint_from_name("kube-control")
+    if not hasattr(kube_control, "set_api_endpoints"):
+        # built with an old version of the kube-control interface
+        # the old kube-api-endpoint relation must be used instead
+        return
     lb_provider = endpoint_from_name("lb-provider")
     if lb_provider.is_available and not lb_provider.has_response:
         # waiting for lb-provider

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2174,6 +2174,17 @@ def build_kubeconfig():
             token=client_pass,
         )
 
+        # Create kubernetes configuration in the default location for ubuntu.
+        create_kubeconfig(
+            "/home/ubuntu/.kube/config",
+            internal_url,
+            ca_crt_path,
+            user="admin",
+            token=client_pass,
+        )
+        # Make the config dir readable by the ubuntu user
+        check_call(["chown", "-R", "ubuntu:ubuntu", "/home/ubuntu/.kube"])
+
         # make a kubeconfig for cdk-addons
         create_kubeconfig(
             cdk_addons_kubectl_config_path,

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -863,10 +863,10 @@ def set_final_status():
         hookenv.status_set("waiting", "Waiting for API server to be configured")
         return
 
-    auth_setup = is_flag_set("authentication.setup")
-    webhook_tokens_setup = is_flag_set("kubernetes-master.auth-webhook-tokens.setup")
-    if auth_setup and not webhook_tokens_setup:
-        hookenv.status_set("waiting", "Failed to setup auth-webhook tokens; will retry")
+    is_leader = is_state("leadership.is_leader")
+    authentication_setup = is_state("authentication.setup")
+    if not is_leader and not authentication_setup:
+        hookenv.status_set("waiting", "Waiting on leader's crypto keys.")
         return
 
     if is_state("kubernetes-master.components.started"):
@@ -887,10 +887,10 @@ def set_final_status():
 
     # Note that after this point, kubernetes-master.components.started is
     # always True.
-    is_leader = is_state("leadership.is_leader")
-    authentication_setup = is_state("authentication.setup")
-    if not is_leader and not authentication_setup:
-        hookenv.status_set("waiting", "Waiting on leader's crypto keys.")
+
+    webhook_tokens_setup = is_flag_set("kubernetes-master.auth-webhook-tokens.setup")
+    if not webhook_tokens_setup:
+        hookenv.status_set("waiting", "Failed to setup auth-webhook tokens; will retry")
         return
 
     addons_configured = is_state("cdk-addons.configured")
@@ -1156,6 +1156,7 @@ def register_auth_webhook():
 
 @when(
     "kubernetes-master.apiserver.configured",
+    "kubernetes-master.components.started",
     "kubernetes-master.auth-webhook-service.started",
     "authentication.setup",
 )

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1429,8 +1429,7 @@ def push_service_data():
 @when("endpoint.lb-provider.available")
 @when_not("kubernetes-master.sent-lb-request")
 def request_load_balancer():
-    """Request a LB from the related provider.
-    """
+    """Request a LB from the related provider."""
     lb_provider = endpoint_from_name("lb-provider")
     req = lb_provider.get_request("api-server")
     req.protocol = req.protocols.tcp
@@ -1458,10 +1457,9 @@ def send_api_endpoints():
     if not endpoints:
         for relation in kube_control.relations:
             endpoints.append(kubernetes_master.get_api_endpoint(relation))
-    kube_control.set_api_endpoints([
-        "https://{}:{}".format(address, port)
-        for address, port in endpoints
-    ])
+    kube_control.set_api_endpoints(
+        ["https://{}:{}".format(address, port) for address, port in endpoints]
+    )
 
 
 @when("certificates.available", "cni.available")
@@ -2732,8 +2730,9 @@ def poke_network_unavailable():
     in a while.
     """
     local_address = get_ingress_address("kube-control")
-    local_server = "https://{0}:{1}".format(local_address,
-                                            kubernetes_master.STANDARD_API_PORT)
+    local_server = "https://{0}:{1}".format(
+        local_address, kubernetes_master.STANDARD_API_PORT
+    )
 
     client_token = get_token("admin")
     http_header = ("Authorization", "Bearer {}".format(client_token))

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -10,13 +10,16 @@ machines:
 services:
   containerd:
     charm: cs:~containers/containerd
+    channel: edge
   easyrsa:
     charm: cs:~containers/easyrsa
+    channel: edge
     num_units: 1
     to:
     - '1'
   etcd:
     charm: cs:~containers/etcd
+    channel: edge
     num_units: 1
     options:
       channel: 3.4/stable
@@ -24,6 +27,7 @@ services:
     - '0'
   flannel:
     charm: cs:~containers/flannel
+    channel: edge
   kubernetes-master:
     charm: {{master_charm}}
     constraints: cores=2 mem=4G root-disk=16G
@@ -35,6 +39,7 @@ services:
     - '0'
   kubernetes-worker:
     charm: cs:~containers/kubernetes-worker
+    channel: edge
     constraints: cores=4 mem=4G root-disk=16G
     expose: true
     num_units: 1
@@ -43,8 +48,6 @@ services:
     to:
     - '1'
 relations:
-- - kubernetes-master:kube-api-endpoint
-  - kubernetes-worker:kube-api-endpoint
 - - kubernetes-master:kube-control
   - kubernetes-worker:kube-control
 - - kubernetes-master:certificates

--- a/tests/integration/test_kubernetes_master_integration.py
+++ b/tests/integration/test_kubernetes_master_integration.py
@@ -9,16 +9,7 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test):
-    bundle = ops_test.render_bundle(
-        "tests/data/bundle.yaml", master_charm=await ops_test.build_charm(".")
-    )
-    await ops_test.model.deploy(bundle)
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
-
-
-async def test_status_messages(ops_test):
+def _check_status_messages(ops_test):
     """Validate that the status messages are correct."""
     expected_messages = {
         "kubernetes-master": "Kubernetes master running.",
@@ -27,6 +18,25 @@ async def test_status_messages(ops_test):
     for app, message in expected_messages.items():
         for unit in ops_test.model.applications[app].units:
             assert unit.workload_status_message == message
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test):
+    bundle = ops_test.render_bundle(
+        "tests/data/bundle.yaml", master_charm=await ops_test.build_charm(".")
+    )
+    await ops_test.model.deploy(bundle)
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
+    _check_status_messages(ops_test)
+
+
+async def test_kube_api_endpoint(ops_test):
+    """Validate that adding the kube-api-endpoint relation works"""
+    await ops_test.model.add_relation(
+        "kubernetes-master:kube-api-endpoint", "kubernetes-worker:kube-api-endpoint"
+    )
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
+    _check_status_messages(ops_test)
 
 
 async def juju_run(unit, cmd):

--- a/tests/unit/test_kubernetes_master.py
+++ b/tests/unit/test_kubernetes_master.py
@@ -134,7 +134,7 @@ def test_status_set_on_missing_ca():
     )
 
 
-def test_stauts_set_on_incomplete_lb():
+def test_status_set_on_incomplete_lb():
     """Test that set_final_status() will set waiting if LB is pending."""
     set_flag("certificates.available")
     clear_flag("kubernetes-master.secure-storage.failed")
@@ -162,12 +162,25 @@ def test_stauts_set_on_incomplete_lb():
     kubernetes_master.set_final_status()
     hookenv.status_set.assert_called_with("active", mock.ANY)
 
-    # test new lb-provider relation
+    # test loadbalancer-internal relation
     clear_flag("kube-api-endpoint.available")
-    hookenv.goal_state.return_value = {"relations": {"lb-provider": None}}
+    hookenv.goal_state.return_value = {"relations": {"loadbalancer-internal": None}}
     endpoint_from_name.return_value.has_response = False
     kubernetes_master.set_final_status()
-    hookenv.status_set.assert_called_with("waiting", "Waiting for lb-provider")
+    hookenv.status_set.assert_called_with(
+        "waiting", "Waiting for loadbalancer-internal"
+    )
+    endpoint_from_name.return_value.has_response = True
+    kubernetes_master.set_final_status()
+    hookenv.status_set.assert_called_with("active", mock.ANY)
+
+    # test loadbalancer-external relation
+    hookenv.goal_state.return_value = {"relations": {"loadbalancer-external": None}}
+    endpoint_from_name.return_value.has_response = False
+    kubernetes_master.set_final_status()
+    hookenv.status_set.assert_called_with(
+        "waiting", "Waiting for loadbalancer-external"
+    )
     endpoint_from_name.return_value.has_response = True
     kubernetes_master.set_final_status()
     hookenv.status_set.assert_called_with("active", mock.ANY)

--- a/tests/unit/test_kubernetes_master.py
+++ b/tests/unit/test_kubernetes_master.py
@@ -153,9 +153,7 @@ def test_stauts_set_on_incomplete_lb():
     hookenv.status_set.assert_called_with("active", mock.ANY)
 
     # test legacy kube-api-endpoint relation
-    hookenv.goal_state.return_value = {
-        "relations": {"kube-api-endpoint": None}
-    }
+    hookenv.goal_state.return_value = {"relations": {"kube-api-endpoint": None}}
     kubernetes_master.set_final_status()
     hookenv.status_set.assert_called_with(
         "waiting", "Waiting for kube-api-endpoint relation"
@@ -166,14 +164,10 @@ def test_stauts_set_on_incomplete_lb():
 
     # test new lb-provider relation
     clear_flag("kube-api-endpoint.available")
-    hookenv.goal_state.return_value = {
-        "relations": {"lb-provider": None}
-    }
+    hookenv.goal_state.return_value = {"relations": {"lb-provider": None}}
     endpoint_from_name.return_value.has_response = False
     kubernetes_master.set_final_status()
-    hookenv.status_set.assert_called_with(
-        "waiting", "Waiting for lb-provider"
-    )
+    hookenv.status_set.assert_called_with("waiting", "Waiting for lb-provider")
     endpoint_from_name.return_value.has_response = True
     kubernetes_master.set_final_status()
     hookenv.status_set.assert_called_with("active", mock.ANY)

--- a/tests/unit/test_kubernetes_master.py
+++ b/tests/unit/test_kubernetes_master.py
@@ -139,8 +139,11 @@ def test_status_set_on_incomplete_lb():
     set_flag("certificates.available")
     clear_flag("kubernetes-master.secure-storage.failed")
     set_flag("kube-control.connected")
+    set_flag("kubernetes-master.auth-webhook-service.started")
+    set_flag("kubernetes-master.apiserver.configured")
     set_flag("kubernetes-master.components.started")
     set_flag("cdk-addons.configured")
+    set_flag("kubernetes-master.auth-webhook-tokens.setup")
     set_flag("kubernetes-master.system-monitoring-rbac-role.applied")
     hookenv.config.return_value = "auto"
     host.service_running.return_value = True

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
 aiohttp>=3.7.4,<4.0.0
 gunicorn>=20.0.0,<21.0.0
+loadbalancer-interface


### PR DESCRIPTION
This adds support for the `loadbalancer` interface so that cloud-native LBs can be provided by the integrator charms. Additionally, it simplifies the confusing way the relations between the masters and workers change depending on whether kubeapi-load-balancer is being used or not by making that use the same `lb-provider` endpoint and always forwarding the API endpoint URLs via the `kube-control` relation.

Part of [lp:1921776][]
Depends on:
  * https://github.com/juju-solutions/loadbalancer-interface/pull/13
  * https://github.com/juju-solutions/interface-kube-control/pull/33
  * https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/84
  * https://github.com/charmed-kubernetes/charm-kubeapi-load-balancer/pull/11

[lp:1921776]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1921776