### PR TITLE
Bump release version in default config and tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.20/stable"
+    default: "1.22/edge"
     description: |
       Snap channel to install Kubernetes master services from
   client_password:

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -10,12 +10,9 @@ machines:
 services:
   containerd:
     charm: cs:~containers/containerd
-    resources: {}
   easyrsa:
     charm: cs:~containers/easyrsa
     num_units: 1
-    resources:
-      easyrsa: 5
     to:
     - '1'
   etcd:
@@ -23,33 +20,17 @@ services:
     num_units: 1
     options:
       channel: 3.4/stable
-    resources:
-      core: 0
-      etcd: 3
-      snapshot: 0
     to:
     - '0'
   flannel:
     charm: cs:~containers/flannel
-    resources:
-      flannel-amd64: 707
-      flannel-arm64: 704
-      flannel-s390x: 691
   kubernetes-master:
-    charm: {{master_charm}}
+    charm: cs:~containers/kubernetes-master
     constraints: cores=2 mem=4G root-disk=16G
     expose: true
     num_units: 1
     options:
-      channel: 1.21/stable
-    resources:
-      cdk-addons: 0
-      core: 0
-      kube-apiserver: 0
-      kube-controller-manager: 0
-      kube-proxy: 0
-      kube-scheduler: 0
-      kubectl: 0
+      channel: 1.22/edge
     to:
     - '0'
   kubernetes-worker:
@@ -58,15 +39,7 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.21/stable
-    resources:
-      cni-amd64: 747
-      cni-arm64: 738
-      cni-s390x: 750
-      core: 0
-      kube-proxy: 0
-      kubectl: 0
-      kubelet: 0
+      channel: 1.22/edge
     to:
     - '1'
 relations:
@@ -92,3 +65,4 @@ relations:
   - kubernetes-worker:container-runtime
 - - containerd:containerd
   - kubernetes-master:container-runtime
+

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -25,7 +25,7 @@ services:
   flannel:
     charm: cs:~containers/flannel
   kubernetes-master:
-    charm: cs:~containers/kubernetes-master
+    charm: {{master_charm}}
     constraints: cores=2 mem=4G root-disk=16G
     expose: true
     num_units: 1

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -32,16 +32,16 @@ services:
   flannel:
     charm: cs:~containers/flannel
     resources:
-      flannel-amd64: 653
-      flannel-arm64: 650
-      flannel-s390x: 637
+      flannel-amd64: 707
+      flannel-arm64: 704
+      flannel-s390x: 691
   kubernetes-master:
     charm: {{master_charm}}
     constraints: cores=2 mem=4G root-disk=16G
     expose: true
     num_units: 1
     options:
-      channel: 1.20/stable
+      channel: 1.21/stable
     resources:
       cdk-addons: 0
       core: 0
@@ -58,11 +58,11 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.20/stable
+      channel: 1.21/stable
     resources:
-      cni-amd64: 690
-      cni-arm64: 681
-      cni-s390x: 693
+      cni-amd64: 747
+      cni-arm64: 738
+      cni-s390x: 750
       core: 0
       kube-proxy: 0
       kubectl: 0


### PR DESCRIPTION
1.21 is now stable. Edge builds from master branch should move up to 1.22.

Test bundle should use use 1.21/stable.  I got the resource IDs for the test updates with the following:
```bash
...
$ charm show ~containers/kubernetes-worker id resources -c stable
id:
  Id: cs:~containers/kubernetes-worker-743
  Name: kubernetes-worker
  Revision: 743
  User: containers
resources:
- Description: CNI plugins for amd64
  Fingerprint: kuelBRY0tv1sH8l8FVIg5g6kcG8yimyr9mLc/96vPag+GeriIw9zj8dZtKNYNlbr
  Name: cni-amd64
  Path: cni.tgz
  Revision: 747
...
```