### PR TITLE
Make auth-webhook async

### DIFF
--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -443,7 +443,7 @@ def is_service_cidr_expansion():
 
 
 def service_cidr():
-    """ Return the charm's service-cidr config"""
+    """Return the charm's service-cidr config"""
     frozen_cidr = db.get("kubernetes-master.service-cidr")
     return frozen_cidr or hookenv.config("service-cidr")
 

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -851,6 +851,14 @@ def set_final_status():
         )
         return
 
+    if not is_flag_set("kubernetes-master.auth-webhook-service.started"):
+        hookenv.status_set("waiting", "Waiting for auth-webhook service to start")
+        return
+
+    if not is_flag_set("kubernetes-master.apiserver.configured"):
+        hookenv.status_set("waiting", "Waiting for API server to be configured")
+        return
+
     auth_setup = is_flag_set("authentication.setup")
     webhook_tokens_setup = is_flag_set("kubernetes-master.auth-webhook-tokens.setup")
     if auth_setup and not webhook_tokens_setup:

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -733,7 +733,7 @@ def get_keys_from_leader(keys, overwrite_local=False):
 
 @when("kubernetes-master.snaps.installed")
 def set_app_version():
-    """ Declare the application version to juju """
+    """Declare the application version to juju"""
     version = check_output(["kube-apiserver", "--version"])
     hookenv.application_version_set(version.split(b" v")[-1].rstrip())
 
@@ -756,7 +756,7 @@ def check_vault_pending():
 
 @hookenv.atexit
 def set_final_status():
-    """ Set the final status of the charm as we leave hook execution """
+    """Set the final status of the charm as we leave hook execution"""
     try:
         goal_state = hookenv.goal_state()
     except NotImplementedError:
@@ -1307,7 +1307,7 @@ def etcd_data_change(etcd):
 @when("kube-control.connected")
 @when("cdk-addons.configured")
 def send_cluster_dns_detail(kube_control):
-    """ Send cluster DNS info """
+    """Send cluster DNS info"""
     dns_provider = endpoint_from_flag("dns-provider.available")
     if dns_provider:
         details = dns_provider.details()
@@ -1522,7 +1522,7 @@ def reconfigure_cdk_addons():
 )
 @when_not("upgrade.series.in-progress")
 def configure_cdk_addons():
-    """ Configure CDK addons """
+    """Configure CDK addons"""
     remove_state("cdk-addons.reconfigure")
     remove_state("cdk-addons.configured")
     remove_state("kubernetes-master.aws.changed")

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -211,6 +211,9 @@ async def forward_request(json_req, url):
                                         verify_ssl=False,
                                         timeout=timeout) as resp:
                     resp_text = await resp.text()
+    except asyncio.TimeoutError:
+        app.logger.error('Timed out contacting server')
+        return False
     except Exception:
         app.logger.exception('Failed to contact server')
         return False
@@ -304,6 +307,14 @@ async def webhook(request):
         return ack(req)
 
     return nak(req)
+
+
+@routes.post('/slow-test')
+async def slow_test(request):
+    app.logger.debug('Slow request started')
+    await asyncio.sleep(5)
+    app.logger.debug('Slow request finished')
+    return aiohttp.web.json_response({'status': {'authenticated': False}})
 
 
 async def refresh_secrets(app):

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -11,9 +11,9 @@ from subprocess import check_call, check_output, CalledProcessError, TimeoutExpi
 from yaml import safe_load
 
 
-AWS_IAM_ENDPOINT = '{{ aws_iam_endpoint }}'
-KEYSTONE_ENDPOINT = '{{ keystone_endpoint }}'
-CUSTOM_AUTHN_ENDPOINT = '{{ custom_authn_endpoint }}'
+AWS_IAM_ENDPOINT = '{{ aws_iam_endpoint if aws_iam_endpoint }}'
+KEYSTONE_ENDPOINT = '{{ keystone_endpoint if keystone_endpoint }}'
+CUSTOM_AUTHN_ENDPOINT = '{{ custom_authn_endpoint if custom_authn_endpoint }}'
 
 app = aiohttp.web.Application()
 routes = aiohttp.web.RouteTableDef()

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -249,7 +249,7 @@ def nak(req, **kwargs):
     return aiohttp.web.json_response(req, **kwargs)
 
 
-@routes.post('/{api_ver}')
+@routes.post('/{{ api_ver }}')
 async def webhook(request):
     '''Listen on /$api_version for POST requests.
 

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -212,7 +212,7 @@ async def forward_request(json_req, url):
                 app.logger.debug('SSLError with server; skipping cert validation')
                 async with session.post(url,
                                         json=json_req,
-                                        verify_ssl=True,
+                                        verify_ssl=False,
                                         timeout=timeout) as resp:
                     resp_text = await resp.text()
     except Exception as e:

--- a/templates/cdk.master.auth-webhook.service
+++ b/templates/cdk.master.auth-webhook.service
@@ -15,6 +15,7 @@ ExecStart={{ charm_dir }}/../.venv/bin/gunicorn \
     --log-level debug \
     --pid {{ pidfile }} \
     --workers {{ num_workers }} \
+    --worker-class aiohttp.worker.GunicornWebWorker \
     auth-webhook:app
 Restart=always
 

--- a/tests/integration/test_kubernetes_master_integration.py
+++ b/tests/integration/test_kubernetes_master_integration.py
@@ -19,7 +19,7 @@ async def test_build_and_deploy(ops_test):
 
 
 async def test_status_messages(ops_test):
-    """ Validate that the status messages are correct. """
+    """Validate that the status messages are correct."""
     expected_messages = {
         "kubernetes-master": "Kubernetes master running.",
         "kubernetes-worker": "Kubernetes worker running.",
@@ -36,7 +36,7 @@ async def juju_run(unit, cmd):
 
 
 async def test_auth_load(ops_test):
-    """ Verify that the auth server can handle heavy load and / or dead endpoints. """
+    """Verify that the auth server can handle heavy load and / or dead endpoints."""
     app = ops_test.model.applications["kubernetes-master"]
     unit = app.units[0]
 

--- a/tests/integration/test_kubernetes_master_integration.py
+++ b/tests/integration/test_kubernetes_master_integration.py
@@ -1,6 +1,9 @@
+import asyncio
 import logging
 
+import aiohttp
 import pytest
+import yaml
 
 
 log = logging.getLogger(__name__)
@@ -24,3 +27,55 @@ async def test_status_messages(ops_test):
     for app, message in expected_messages.items():
         for unit in ops_test.model.applications[app].units:
             assert unit.workload_status_message == message
+
+
+async def juju_run(unit, cmd):
+    result = await unit.run(cmd)
+    assert result.results["Code"] == "0"
+    return result.results.get("Stdout")
+
+
+async def test_auth_load(ops_test):
+    """ Verify that the auth server can handle heavy load and / or dead endpoints. """
+    app = ops_test.model.applications["kubernetes-master"]
+    unit = app.units[0]
+
+    log.info("Opening auth-webhook port")
+    await juju_run(unit, "open-port 5000")
+
+    log.info("Getting internal auth address")
+    auth_addr = await juju_run(unit, "network-get --ingress-address kube-api-endpoint")
+
+    log.info("Getting admin token")
+    kubeconfig = yaml.safe_load(await juju_run(unit, "cat /home/ubuntu/config"))
+    valid_token = kubeconfig["users"][0]["user"]["token"]
+    invalid_token = "invalid"
+
+    log.info("Configuring custom endpoint")
+    url = f"https://{auth_addr.strip()}:5000/slow-test"
+    await app.set_config({"authn-webhook-endpoint": url})
+
+    log.info("Waiting for model to settle")
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
+
+    async def _auth_req(token, timeout=30):
+        url = f"https://{unit.public_address}:5000/v1beta1"
+        req = {"kind": "TokenReview", "spec": {"token": token}}
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url, json=req, timeout=timeout, verify_ssl=False
+            ) as resp:
+                resp_json = await resp.json()
+                return resp_json["status"]["authenticated"]
+
+    log.info("Starting 20 background slow auth requests")
+    tasks = [asyncio.create_task(_auth_req(invalid_token)) for _ in range(20)]
+
+    log.info("Waiting for slow auth requests to block")
+    await asyncio.sleep(1)
+
+    log.info("Verifying one concurrent good auth request")
+    assert await _auth_req(valid_token, timeout=5)
+
+    log.info("Waiting for slow auth requests to complete")
+    assert not any(await asyncio.gather(*tasks))

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,9 @@ commands = pytest --tb native -s {posargs} {toxinidir}/tests/unit
 
 [testenv:integration]
 deps =
-    # Until 2.8.6 is released
-    https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
     pytest-operator
+    aiohttp
     ipdb
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,3 @@
 flask>=1.0.0,<2.0.0
 gunicorn>=20.0.0,<21.0.0
+aiohttp

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,4 +1,2 @@
-flask>=1.0.0,<2.0.0
+aiohttp>=3.7.4,<4.0.0
 gunicorn>=20.0.0,<21.0.0
-Werkzeug<2.0.0
-aiohttp


### PR DESCRIPTION
This converts auth-webhook from a synchronous Flask app managed by gunicorn to an asynchronous aiohttp app managed by gunicorn. This allows it to process any number of concurrent requests even if requests end up blocked or timing out on a configured external auth endpoint (keystone, custom addr, etc).

Fixes: [lp:1927145][]

[lp:1927145]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1927145