### PR TITLE
Remove dropped kube-apiserver arg

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -2230,7 +2230,6 @@ def configure_apiserver():
     api_opts["kubelet-certificate-authority"] = str(ca_crt_path)
     api_opts["kubelet-client-certificate"] = str(client_crt_path)
     api_opts["kubelet-client-key"] = str(client_key_path)
-    api_opts["kubelet-https"] = "true"
     api_opts["logtostderr"] = "true"
     api_opts["storage-backend"] = getStorageBackend()
     api_opts["insecure-port"] = "0"


### PR DESCRIPTION
The `--kubelet-https` arg has been [deprecated][] since 1.19 and has been dropped entirely in 1.22, breaking the deployment.

[deprecated]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#other-cleanup-or-flake-5