### PR TITLE
Use ensure_future instead of create_task

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Install Dependencies
-        run: |
-          pip install tox
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@master
+        with:
+          provider: vsphere
+          credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
+          clouds-yaml: ${{ secrets.CLOUDS_YAML }}
+          bootstrap-options: "--model-default datastore=vsanDatastore --model-default primary-network=VLAN_2764"
       - name: Run test
         run: tox -e integration

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -398,7 +398,7 @@ async def startup(app):
                 app.logger.exception('Failed to get secrets')
 
     app['secrets'] = {}
-    app['secrets_task'] = asyncio.create_task(_task())
+    app['secrets_task'] = asyncio.ensure_future(_task())
 
 
 async def cleanup(app):


### PR DESCRIPTION
The `create_task()` function was only added to `asyncio` in 3.7, so bionic and before need to use the older (but equivalent) `ensure_future()`.

Fixes [lp:1928737](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1928737)