### PR TITLE
Improve status reporting during deploy

### DIFF
--- a/tests/integration/test_kubernetes_master_integration.py
+++ b/tests/integration/test_kubernetes_master_integration.py
@@ -29,7 +29,9 @@ async def test_build_and_deploy(ops_test):
     # Use CLI to deploy bundle until https://github.com/juju/python-libjuju/pull/497
     # is released.
     # await ops_test.model.deploy(bundle)
-    retcode, stdout, stderr = await ops_test._run("juju", "deploy", bundle)
+    retcode, stdout, stderr = await ops_test._run(
+        "juju", "deploy", "-m", ops_test.model_full_name, bundle
+    )
     assert retcode == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
     log.info(stdout)
     await ops_test.model.block_until(

--- a/tests/integration/test_kubernetes_master_integration.py
+++ b/tests/integration/test_kubernetes_master_integration.py
@@ -25,8 +25,28 @@ async def test_build_and_deploy(ops_test):
     bundle = ops_test.render_bundle(
         "tests/data/bundle.yaml", master_charm=await ops_test.build_charm(".")
     )
-    await ops_test.model.deploy(bundle)
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
+    # Use CLI to deploy bundle until https://github.com/juju/python-libjuju/pull/497
+    # is released.
+    # await ops_test.model.deploy(bundle)
+    retcode, stdout, stderr = await ops_test._run("juju", "deploy", bundle)
+    assert retcode == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
+    log.info(stdout)
+    try:
+        await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
+    except asyncio.TimeoutError:
+        if "kubernetes-master" not in ops_test.model.applications:
+            raise
+        app = ops_test.model.applications["kubernetes-master"]
+        if not app.units:
+            raise
+        unit = app.units[0]
+        if "kube-system pod" in unit.workload_status_message:
+            log.debug(
+                await juju_run(
+                    unit, "kubectl --kubeconfig /root/.kube/config get all -A"
+                )
+            )
+        raise
     _check_status_messages(ops_test)
 
 
@@ -41,8 +61,11 @@ async def test_kube_api_endpoint(ops_test):
 
 async def juju_run(unit, cmd):
     result = await unit.run(cmd)
-    assert result.results["Code"] == "0"
-    return result.results.get("Stdout")
+    code = result.results["Code"]
+    stdout = result.results.get("Stdout")
+    stderr = result.results.get("Stderr")
+    assert code == "0", f"{cmd} failed ({code}): {stderr or stdout}"
+    return stdout
 
 
 async def test_auth_load(ops_test):

--- a/tests/unit/test_kubernetes_master.py
+++ b/tests/unit/test_kubernetes_master.py
@@ -139,11 +139,16 @@ def test_status_set_on_incomplete_lb():
     set_flag("certificates.available")
     clear_flag("kubernetes-master.secure-storage.failed")
     set_flag("kube-control.connected")
+    set_flag("etcd.available")
+    set_flag("cni.available")
+    set_flag("tls_client.certs.saved")
     set_flag("kubernetes-master.auth-webhook-service.started")
     set_flag("kubernetes-master.apiserver.configured")
+    set_flag("kubernetes-master.apiserver.running")
+    set_flag("authentication.setup")
+    set_flag("kubernetes-master.auth-webhook-tokens.setup")
     set_flag("kubernetes-master.components.started")
     set_flag("cdk-addons.configured")
-    set_flag("kubernetes-master.auth-webhook-tokens.setup")
     set_flag("kubernetes-master.system-monitoring-rbac-role.applied")
     hookenv.config.return_value = "auto"
     host.service_running.return_value = True


### PR DESCRIPTION
Certain issues during deploy, such as the API server failing to start, can be misreported in status as "Failed to to setup auth-webhook tokens" rather than a more specific and useful message.

Fixes [lp:1928951][]

[lp:1928951]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1928951