### PR TITLE
Added support for new enable-csi-snapshots option in cdk-addons

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -172,6 +172,11 @@ options:
     default: true
     description: |
       If true the metrics server for Kubernetes will be deployed onto the cluster.
+  enable-csi-snapshots:
+    type: boolean
+    default: true
+    description: |
+      If true CSI snapshot support will be deployed onto the cluster.
   snapd_refresh:
     default: "max"
     type: string

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -588,6 +588,18 @@ def enable_metric_changed():
         configure_cdk_addons()
 
 
+@when("etcd.available")
+@when("config.changed.enable-csi-snapshots")
+def enable_csi_snapshots_changed():
+    """
+    Trigger CDK addon configuration if enable-csi-snapshots is updated.
+
+    :return: None
+    """
+    if is_state("leadership.is_leader"):
+        configure_cdk_addons()
+
+
 @when("config.changed.client_password", "leadership.is_leader")
 def password_changed():
     """Handle password change by reconfiguring authentication."""
@@ -1599,6 +1611,7 @@ def configure_cdk_addons():
         hookenv.log(traceback.format_exc())
         return
     metricsEnabled = str(hookenv.config("enable-metrics")).lower()
+    csiSnapshotsEnabled = str(hookenv.config("enable-csi-snapshots")).lower()
     default_storage = ""
     ceph = {}
     ceph_ep = endpoint_from_flag("ceph-storage.available")
@@ -1663,6 +1676,7 @@ def configure_cdk_addons():
         "registry=" + registry,
         "enable-dashboard=" + dbEnabled,
         "enable-metrics=" + metricsEnabled,
+        "enable-csi-snapshots=" + csiSnapshotsEnabled,
         "enable-gpu=" + str(gpuEnable).lower(),
         "enable-ceph=" + cephEnabled,
         "enable-cephfs=" + cephFsEnabled,


### PR DESCRIPTION
This is an attempt (perhaps naive) at addressing https://bugs.launchpad.net/cdk-addons/+bug/1926494.

Dependencies:
* Patch to cdk-addons: https://github.com/charmed-kubernetes/cdk-addons/pull/206
* rocks.canonical.com:443/cdk does not have a copy of k8s.gcr.io/sig-storage/snapshot-controller:v3.0.2, and so the volume-snapshot-controler StatefulSet's pods will not spin up correctly right now unless the image is patched to look at the k8s.gcr.io version.

Also, I acknowledge that there are no tests for this.  I've reviewed the unit and integration tests currently present for this charm, and while technically I could write an integration test for this, it wouldn't really match the scope of the tests which presently exist here, so it didn't quite feel appropriate.  However, if you have suggestions for a test case you think would be suitable, I'm happy to do it; please let me know.