### PR TITLE
Fix NoneType error when using old loadbalancer relation

### DIFF
--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -135,7 +135,7 @@ def get_external_api_endpoints():
 
     # Support the older loadbalancer relation (public-address interface).
     if "loadbalancer" in goal_state["relations"]:
-        loadbalancer = endpoint_from_flag("loadbalancer.available")
+        loadbalancer = endpoint_from_name("loadbalancer")
         lb_addresses = loadbalancer.get_addresses_ports()
         return [(host.get("public-address"), host.get("port")) for host in lb_addresses]
 

--- a/tests/unit/test_kubernetes_master.py
+++ b/tests/unit/test_kubernetes_master.py
@@ -43,7 +43,7 @@ def test_series_upgrade():
 def configure_apiserver(service_cidr_from_db, service_cidr_from_config):
     set_flag("leadership.is_leader")
     db = unitdata.kv()
-    db.get.return_value = service_cidr_from_db
+    db.set("kubernetes-master.service-cidr", service_cidr_from_db)
     hookenv.config.return_value = service_cidr_from_config
     get_version.return_value = (1, 18)
     kubernetes_master.configure_apiserver()
@@ -99,7 +99,8 @@ def test_service_cidr_expansion():
     clear_flag("kubernetes-master.had-service-cidr-expanded")
     configure_apiserver("10.152.183.0/24,fe80::/120", "10.152.183.0/24,fe80::/112")
     assert is_flag_set("kubernetes-master.had-service-cidr-expanded")
-    unitdata.kv().get.return_value = "10.152.0.0/16"
+    db = unitdata.kv()
+    db.set("kubernetes-master.service-cidr", "10.152.0.0/16")
     update_for_service_cidr_expansion()
     assert kubectl.call_count == 4
 


### PR DESCRIPTION
If the legacy `loadbalancer` relation is in `goal-state` but not yet ready, the following error can occur:

```
  File "lib/charms/layer/kubernetes_master.py", line 139, in get_external_api_endpoints
    lb_addresses = loadbalancer.get_addresses_ports()
AttributeError: 'NoneType' object has no attribute 'get_addresses_ports'
```

This fixes it by making that section use `endpoint_from_name` like all the other calls in that function and its internal counterpart.