### PR TITLE
Fix missed reference to get_api_endpoint

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -3433,7 +3433,10 @@ def register_prometheus_jobs():
     monitoring_token = get_token("system:monitoring")
 
     for relation in prometheus.relations:
-        address, port = kubernetes_master.get_api_endpoint(relation)
+        endpoints = kubernetes_master.get_internal_api_endpoints(relation)
+        if not endpoints:
+            continue
+        address, port = endpoints[0]
 
         templates_dir = Path("templates")
         for job_file in Path("templates/prometheus").glob("*.yaml.j2"):

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -47,6 +47,11 @@ services:
       channel: 1.22/edge
     to:
     - '1'
+  prometheus:
+    charm: cs:prometheus2
+    num_units: 1
+    to:
+      - '0'
 relations:
 - - kubernetes-master:kube-control
   - kubernetes-worker:kube-control
@@ -68,4 +73,5 @@ relations:
   - kubernetes-worker:container-runtime
 - - containerd:containerd
   - kubernetes-master:container-runtime
-
+- - kubernetes-master:prometheus
+  - prometheus:manual-jobs


### PR DESCRIPTION
The LB support PR changed the functions used to get the API endpoints, but one instance was missed when using Prometheus. Fixed that, and also added Prometheus to the integration tests just to do a basic validation of that.

Fixes [lp:1934307](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1934307)