### PR TITLE
Don't bind auth webhook daemon to the virtual IP

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1033,7 +1033,9 @@ def register_auth_webhook():
     context = {
         "api_ver": "v1beta1",
         "charm_dir": hookenv.charm_dir(),
-        "host": get_ingress_address("kube-api-endpoint"),
+        "host": get_ingress_address(
+            "kube-api-endpoint", ignore_addresses=[hookenv.config("ha-cluster-vip")]
+        ),
         "pidfile": "auth-webhook.pid",
         "port": 5000,
         "root_dir": auth_webhook_root,

--- a/tests/unit/test_kubernetes_master.py
+++ b/tests/unit/test_kubernetes_master.py
@@ -253,3 +253,14 @@ def test_setup_auth_webhook_tokens(kcs, ctsar):
     set_flag("authentication.setup")
     kubernetes_master.setup_auth_webhook_tokens()
     assert not is_flag_set("authentication.setup")
+
+
+@mock.patch.object(kubernetes_master, "render", autospec=True)
+@mock.patch.object(kubernetes_master, "get_ingress_address", autospec=True)
+def test_ignore_vip(get_ingress_address, render):
+    get_ingress_address.return_value = "5.6.7.8"
+    hookenv.config.return_value = "1.2.3.4"
+    kubernetes_master.register_auth_webhook()
+    get_ingress_address.assert_called_with(
+        "kube-api-endpoint", ignore_addresses=["1.2.3.4"]
+    )


### PR DESCRIPTION
There are cases where Juju could return a configured virtual IP address
as an ingress address, this change will mark the configured ha-cluster-vip
to be ignored when retrieving the list of ingress-addresses, this prevent
the charm from rendering a configuration for cdk.master.auth-webhook.service
that will bind the process to a IP address that's not configured in the host
anymore.

Fixes [lp:1925382](https://bugs.launchpad.net/bugs/1925382)
Depends-On: https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/20