### PR TITLE
stop unconfining in the lxd profile

### DIFF
--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -2,7 +2,6 @@ name: juju-default-k8s-deployment-0
 config:
   linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
   raw.lxc: |
-    lxc.apparmor.profile=unconfined
     lxc.mount.auto=proc:rw sys:rw
     lxc.cgroup.devices.allow=a
     lxc.cap.drop=


### PR DESCRIPTION
Remove `lxc.apparmor.profile=unconfined` from `lxd-profile.yaml`.

At least 3+ years ago, our (now deprecated) [bundle wiki](https://github.com/charmed-kubernetes/bundle/wiki/Deploying-on-LXD/80068c018ffb5ab50a03a02058188ef6670c1786) mentioned the need to use privileged containers for deployment to lxd.  This caused a recent issue where k8s snaps would fail to install with mismatched host/container snapd versions (around the snapd-2.48 timeframe).

This PR removes the `unconfined` profile config. In my testing, there hasn't been any noticeable change in CK capabilities; snaps install fine and workloads (priv'd and not) function as expected.  I suspect an unconfined container was once needed for container nesting or privileged workloads (maybe due to dockerd/containerd limitations in the past?), but this no longer seems to be the case.

Fixes [LP 1907153](https://bugs.launchpad.net/snapd/+bug/1907153).