### PR TITLE
Allow custom layers / interfaces to be used in integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ envlist = lint,unit,integration
 setenv =
     PYTHONPATH={toxinidir}:{toxinidir}/lib
     PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_LAYERS_DIR={toxinidir}/layers
+    CHARM_INTERFACES_DIR={toxinidir}/interfaces
 
 [testenv:unit]
 deps =


### PR DESCRIPTION
`charm build` will pull layers and interfaces from the index by default,
but when a patch depends on changes non upstreamed to test locally the
environment variables CHARM_INTERFACES_DIR and CHARM_LAYERS_DIR need to
be set to the path where the interfaces and layers are in the local
machine.