### PR TITLE
CK-124 - Fix port for loadbalancer-external

### DIFF
--- a/lib/charms/layer/kubernetes_master.py
+++ b/lib/charms/layer/kubernetes_master.py
@@ -22,6 +22,7 @@ from charms.layer.kubernetes_common import AUTH_SECRET_NS, create_secret
 AUTH_BACKUP_EXT = "pre-secrets"
 AUTH_BASIC_FILE = "/root/cdk/basic_auth.csv"
 AUTH_TOKENS_FILE = "/root/cdk/known_tokens.csv"
+EXTERNAL_API_PORT = 443
 STANDARD_API_PORT = 6443
 CEPH_CONF_DIR = Path("/etc/ceph")
 CEPH_CONF = CEPH_CONF_DIR / "ceph.conf"
@@ -75,12 +76,13 @@ def get_internal_api_endpoints(relation=None):
     for lb_type in ("internal", "external"):
         lb_endpoint = "loadbalancer-" + lb_type
         request_name = "api-server-" + lb_type
+        api_port = EXTERNAL_API_PORT if lb_type == "external" else STANDARD_API_PORT
         if lb_endpoint in goal_state["relations"]:
             lb_provider = endpoint_from_name(lb_endpoint)
             lb_response = lb_provider.get_response(request_name)
             if not lb_response or lb_response.error:
                 return []
-            return [(lb_response.address, STANDARD_API_PORT)]
+            return [(lb_response.address, api_port)]
 
     # Support the older loadbalancer relation (public-address interface).
     if "loadbalancer" in goal_state["relations"]:
@@ -122,12 +124,13 @@ def get_external_api_endpoints():
     for lb_type in ("external", "internal"):
         lb_endpoint = "loadbalancer-" + lb_type
         lb_name = "api-server-" + lb_type
+        api_port = EXTERNAL_API_PORT if lb_type == "external" else STANDARD_API_PORT
         if lb_endpoint in goal_state["relations"]:
             lb_provider = endpoint_from_name(lb_endpoint)
             lb_response = lb_provider.get_response(lb_name)
             if not lb_response or lb_response.error:
                 return []
-            return [(lb_response.address, STANDARD_API_PORT)]
+            return [(lb_response.address, api_port)]
 
     # Support the older loadbalancer relation (public-address interface).
     if "loadbalancer" in goal_state["relations"]:

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1399,7 +1399,7 @@ def request_load_balancers():
         if not req.health_checks:
             req.add_health_check(
                 protocol=req.protocols.http,
-                port=api_port,
+                port=int_api_port,
                 path="/livez",
             )
         lb_provider.send_request(req)

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1391,8 +1391,10 @@ def request_load_balancers():
             continue
         req = lb_provider.get_request("api-server-" + lb_type)
         req.protocol = req.protocols.tcp
-        api_port = kubernetes_master.STANDARD_API_PORT
-        req.port_mapping = {api_port: api_port}
+        ext_api_port = kubernetes_master.EXTERNAL_API_PORT
+        int_api_port = kubernetes_master.STANDARD_API_PORT
+        api_port = ext_api_port if lb_type == "external" else int_api_port
+        req.port_mapping = {api_port: int_api_port}
         req.public = lb_type == "external"
         if not req.health_checks:
             req.add_health_check(


### PR DESCRIPTION
The old external LB support using kubeapi-load-balancer and the old public-address interface used the default config value for the port from the ka-l-b charm of 443. The switch to the new loadbalancer interface ended up unintentionally switching that in the default configuration to use the standard API port of 6443 which broke the test_sans test case.