### PR TITLE
make 1.23/edge the default channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.22/edge"
+    default: "1.23/edge"
     description: |
       Snap channel to install Kubernetes master services from
   client_password:

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -34,7 +34,7 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.22/edge
+      channel: 1.23/edge
     to:
     - '0'
   kubernetes-worker:
@@ -44,7 +44,7 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.22/edge
+      channel: 1.23/edge
     to:
     - '1'
   prometheus:


### PR DESCRIPTION
Now that 1.22 is going stable, move our master branches up to 1.23/edge.