### PR TITLE
make 1.22/stable the default channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.22/edge"
+    default: "1.22/stable"
     description: |
       Snap channel to install Kubernetes master services from
   client_password:

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -34,7 +34,7 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.22/edge
+      channel: 1.22/stable
     to:
     - '0'
   kubernetes-worker:
@@ -44,7 +44,7 @@ services:
     expose: true
     num_units: 1
     options:
-      channel: 1.22/edge
+      channel: 1.22/stable
     to:
     - '1'
   prometheus:


### PR DESCRIPTION
In preparation for the 1.22 release, make 1.22/stable the default channel in the `stable` branch.