### PR TITLE
Revert "stop unconfining in the lxd profile (#168)"

### DIFF
--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -2,6 +2,7 @@ name: juju-default-k8s-deployment-0
 config:
   linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay
   raw.lxc: |
+    lxc.apparmor.profile=unconfined
     lxc.mount.auto=proc:rw sys:rw
     lxc.cgroup.devices.allow=a
     lxc.cap.drop=


### PR DESCRIPTION
This reverts commit cb3884db1ee9e1c2e0e143b10f673a4bef2bef22.

Needed to address a calico/vxlan issue when k-m is in lxd:

https://bugs.launchpad.net/charm-calico/+bug/1942099

We'll revisit in a future bugfix release to confine the profile and still support calico/vxlan in lxd.