### PR TITLE
Fix action branch and wheelhouse validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@master
+        uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,12 @@ deps =
 commands = pytest --tb native -s {posargs} {toxinidir}/tests/unit
 
 [testenv:validate-wheelhouse]
+deps =
+# Temporarily pin setuptools to avoid the breaking change from 58 until
+# all dependencies we use have a chance to update.
+# See: https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0
+# and: https://github.com/pypa/setuptools/issues/2784#issuecomment-917663223
+    setuptools<58
 allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
 commands = {toxinidir}/tests/validate-wheelhouse.sh
 


### PR DESCRIPTION
Branch for actions-operator was renamed, and setuptools released a breaking change that only affects the validate-wheelhouse test, not the actual charm deploys (since the base VMs for deploys won't have the newer setuptools).