### PR TITLE
LP#1936816 - auth-webhook.pid to /run/ and auth-webhook.log to /var/log

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -127,7 +127,7 @@ keystone_policy_path = os.path.join(keystone_root, "keystone-policy.yaml")
 kubecontrollermanagerconfig_path = "/root/cdk/kubecontrollermanagerconfig"
 kubeschedulerconfig_path = "/root/cdk/kubeschedulerconfig"
 cdk_addons_kubectl_config_path = "/root/cdk/cdk_addons_kubectl_config"
-cdk_logs = "/var/log/cdk/"
+kubernetes_logs = "/var/log/kubernetes/"
 aws_iam_webhook = "/root/cdk/aws-iam-webhook.yaml"
 auth_webhook_root = "/root/cdk/auth-webhook"
 auth_webhook_conf = os.path.join(auth_webhook_root, "auth-webhook-conf.yaml")
@@ -1081,8 +1081,8 @@ def register_auth_webhook():
     if custom_authn:
         context["custom_authn_endpoint"] = custom_authn
 
-    cdk_log_path = Path(cdk_logs)
-    cdk_log_path.mkdir(parents=True, exist_ok=True)  # ensure log path exists
+    k8s_log_path = Path(kubernetes_logs)
+    k8s_log_path.mkdir(parents=True, exist_ok=True)  # ensure log path exists
     render("cdk.master.auth-webhook-conf.yaml", auth_webhook_conf, context)
     render("cdk.master.auth-webhook.py", auth_webhook_exe, context)
     render(
@@ -1091,8 +1091,8 @@ def register_auth_webhook():
 
     # Move existing log files from ${auth_webhook_root} to /var/log/cdk/
     for log_file in Path(auth_webhook_root).glob("auth-webhook.log*"):
-        if not (cdk_log_path / log_file.name).exists():
-            shutil.move(str(log_file), str(cdk_log_path))
+        if not (k8s_log_path / log_file.name).exists():
+            shutil.move(str(log_file), str(k8s_log_path))
 
     # Set the number of gunicorn workers based on our core count. (2*cores)+1 is
     # recommended: https://docs.gunicorn.org/en/stable/design.html#how-many-workers

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1036,7 +1036,7 @@ def register_auth_webhook():
         "host": get_ingress_address(
             "kube-api-endpoint", ignore_addresses=[hookenv.config("ha-cluster-vip")]
         ),
-        "pidfile": "auth-webhook.pid",
+        "pidfile": Path("/") / "run" / "auth-webhook.pid",
         "port": 5000,
         "root_dir": auth_webhook_root,
     }

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -17,7 +17,6 @@
 import base64
 import os
 import re
-import shutil
 import socket
 import json
 import traceback
@@ -1089,10 +1088,12 @@ def register_auth_webhook():
         "cdk.master.auth-webhook.logrotate", "/etc/logrotate.d/auth-webhook", context
     )
 
-    # Move existing log files from ${auth_webhook_root} to /var/log/cdk/
+    # Move existing log files from ${auth_webhook_root} to /var/log/kubernetes/
     for log_file in Path(auth_webhook_root).glob("auth-webhook.log*"):
-        if not (k8s_log_path / log_file.name).exists():
-            shutil.move(str(log_file), str(k8s_log_path))
+        # all historical log files (.log, .log.1 and .log.3.tgz)
+        new_log_file = k8s_log_path / ("cdk.master." + log_file.name)
+        if not new_log_file.exists():
+            move(str(log_file), str(new_log_file))
 
     # Set the number of gunicorn workers based on our core count. (2*cores)+1 is
     # recommended: https://docs.gunicorn.org/en/stable/design.html#how-many-workers

--- a/templates/cdk.master.auth-webhook.logrotate
+++ b/templates/cdk.master.auth-webhook.logrotate
@@ -1,4 +1,4 @@
-{{ root_dir }}/*.log {
+/var/log/cdk/{{logfile}} {
     daily
     rotate 10
     missingok
@@ -6,6 +6,6 @@
     compress
     sharedscripts
     postrotate
-        kill -USR1 $(cat {{ root_dir }}/{{ pidfile }})
+        kill -USR1 $(cat /run/{{ pidfile }})
     endscript
 }

--- a/templates/cdk.master.auth-webhook.logrotate
+++ b/templates/cdk.master.auth-webhook.logrotate
@@ -1,4 +1,4 @@
-/var/log/cdk/{{logfile}} {
+/var/log/kubernetes/{{logfile}} {
     daily
     rotate 10
     missingok

--- a/templates/cdk.master.auth-webhook.service
+++ b/templates/cdk.master.auth-webhook.service
@@ -10,11 +10,11 @@ ExecStart={{ charm_dir }}/../.venv/bin/gunicorn \
     --bind {{ host }}:{{ port }} \
     --capture-output \
     --certfile /root/cdk/server.crt \
-    --disable-redirect-access-to-syslog \
-    --error-logfile auth-webhook.log \
     --keyfile /root/cdk/server.key \
+    --disable-redirect-access-to-syslog \
+    --error-logfile /var/log/cdk/{{logfile}} \
     --log-level debug \
-    --pid {{ pidfile }} \
+    --pid /run/{{ pidfile }} \
     --workers {{ num_workers }} \
     --worker-class aiohttp.worker.GunicornWebWorker \
     auth-webhook:app

--- a/templates/cdk.master.auth-webhook.service
+++ b/templates/cdk.master.auth-webhook.service
@@ -12,7 +12,7 @@ ExecStart={{ charm_dir }}/../.venv/bin/gunicorn \
     --certfile /root/cdk/server.crt \
     --keyfile /root/cdk/server.key \
     --disable-redirect-access-to-syslog \
-    --error-logfile /var/log/cdk/{{logfile}} \
+    --error-logfile /var/log/kubernetes/{{logfile}} \
     --log-level debug \
     --pid /run/{{ pidfile }} \
     --workers {{ num_workers }} \


### PR DESCRIPTION
* address bug: move auth-webhook.pid to /run rather than /root/cdk
* address bug: move auth-webhook.log to `/var/log/kubernetes`
* move existing auth-webhook logs to `/var/log/kubernetes`
* update logrotated configuration to appropriate rotate the logs in their new home
* add NRPE check to ensure the `cdk.master.auth-webhook` service is running