### PR TITLE
pin aiohttp < 3.8.0 due to its requirement on setuptools 46.4.0

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,3 @@
-aiohttp>=3.7.4,<4.0.0
+aiohttp>=3.7.4,<3.8.0
 gunicorn>=20.0.0,<21.0.0
 loadbalancer-interface


### PR DESCRIPTION
aiohttp requires setuptools 46.4.0 or above since this commit https://github.com/aio-libs/aiohttp/commit/f8b07dd62facc4c004b349d6e16b790f4b7205c2into the 3.8 branch 

layer-basic pins setuptools < 42 https://github.com/juju-solutions/layer-basic/blob/a3ff62c32c993d80417f6e093e3ef95e42f62083/wheelhouse.txt#L10

Until a decision is made about whether to relax layer-basic or push on aiohttp to move backwards, just pin aiohttp to < 3.8.0