### PR TITLE
Remove deprecated call to CNI relation set_config

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -548,14 +548,6 @@ def storage_backend_changed():
     remove_state("kubernetes-master.components.started")
 
 
-@when("cni.connected")
-@when_not("cni.configured")
-def configure_cni(cni):
-    """Set master configuration on the CNI relation. This lets the CNI
-    subordinate know that we're the master so it can respond accordingly."""
-    cni.set_config(is_master=True)
-
-
 @when("leadership.is_leader")
 @when_not("authentication.setup")
 def setup_leader_authentication():


### PR DESCRIPTION
CNI subordinate behavior will no longer differ between masters and workers. As such, `is_master` is being removed from the CNI relation, and since there is no other config to set, `cni.set_config` is going away too. So this just cleans up nicely.

This is needed to support adding kubelet to kubernetes-master.