### PR TITLE
Existing tests pass with the inclusion of keystone

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,11 @@
-from kubernetes_wrapper import Kubernetes
 import logging
 import pytest
 import random
 import string
+
+from lightkube import KubeConfig, Client
+from lightkube.resources.core_v1 import Namespace
+from lightkube.models.meta_v1 import ObjectMeta
 
 log = logging.getLogger(__name__)
 
@@ -24,17 +27,16 @@ async def kubernetes(ops_test):
         log.error(f"stdout:\n{stdout.strip()}")
         log.error(f"stderr:\n{stderr.strip()}")
         pytest.fail("Failed to copy kubeconfig from kubernetes-master")
-    namespace = "test-kubernetes-master-integration-" + "".join(
-        random.choice(string.ascii_lowercase + string.digits) for _ in range(5)
+
+    namespace = (
+        "test-kubernetes-master-integration-"
+        + random.choice(string.ascii_lowercase + string.digits) * 5
     )
-    kubernetes = Kubernetes(
-        namespace, kubeconfig=str(kubeconfig_path), context="juju-context"
+    config = KubeConfig.from_file(kubeconfig_path)
+    kubernetes = Client(
+        config=config.get(context_name="juju-context"), namespace=namespace
     )
-    namespace_object = {
-        "apiVersion": "v1",
-        "kind": "Namespace",
-        "metadata": {"name": namespace},
-    }
-    kubernetes.apply_object(namespace_object)
+    namespace_obj = Namespace(metadata=ObjectMeta(name=namespace))
+    kubernetes.create(namespace_obj)
     yield kubernetes
-    kubernetes.delete_object(namespace_object)
+    kubernetes.delete(Namespace, namespace)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,22 @@ from lightkube import KubeConfig, Client
 from lightkube.resources.core_v1 import Namespace
 from lightkube.models.meta_v1 import ObjectMeta
 
+# Quick hack to set `trust_env=False` on the httpx client,
+# so that it ignores environment *_proxy settings.
+# Issue with lightkube here: https://github.com/gtsystem/lightkube/issues/19
+from lightkube.core.generic_client import GenericClient
+from lightkube.config.client_adapter import httpx_parameters
+from lightkube.config.kubeconfig import SingleConfig
+import httpx
+
+
+def CustomClient(config: SingleConfig, timeout: httpx.Timeout) -> httpx.Client:
+    return httpx.Client(trust_env=False, **httpx_parameters(config, timeout))
+
+
+GenericClient.AdapterClient = staticmethod(CustomClient)
+# -------------------------------------------------------------------------------------------
+
 log = logging.getLogger(__name__)
 
 

--- a/tests/validate-wheelhouse.sh
+++ b/tests/validate-wheelhouse.sh
@@ -4,5 +4,5 @@ build_dir="$(mktemp -d)"
 function cleanup { rm -rf "$build_dir"; }
 trap cleanup EXIT
 
-charm build . --build-dir "$build_dir"
+charm build . --build-dir "$build_dir" --debug
 pip install -f "$build_dir/kubernetes-master/wheelhouse" --no-index --no-cache-dir "$build_dir"/kubernetes-master/wheelhouse/*

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     pytest-operator
     aiohttp
     ipdb
-    git+https://github.com/canonical/kubernetes-rapper@main#egg=kubernetes-wrapper
+    lightkube
 commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:lint]

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,4 @@
 aiohttp>=3.7.4,<3.8.0
 gunicorn>=20.0.0,<21.0.0
 loadbalancer-interface
+typing_extensions<4.0


### PR DESCRIPTION
Adding keystone and related components to integration tests bundle:
`keystone`
`keystone-mysql-router`
`mysql-innodb-cluster`

updated tests to use the `juju-context` from the generated kubeconfig
