### PR TITLE
Restrict typing_extentions < 4.0

### DIFF
--- a/tests/validate-wheelhouse.sh
+++ b/tests/validate-wheelhouse.sh
@@ -4,5 +4,5 @@ build_dir="$(mktemp -d)"
 function cleanup { rm -rf "$build_dir"; }
 trap cleanup EXIT
 
-charm build . --build-dir "$build_dir"
+charm build . --build-dir "$build_dir" --debug
 pip install -f "$build_dir/kubernetes-master/wheelhouse" --no-index --no-cache-dir "$build_dir"/kubernetes-master/wheelhouse/*

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,4 @@
 aiohttp>=3.7.4,<3.8.0
 gunicorn>=20.0.0,<21.0.0
 loadbalancer-interface
+typing_extensions<4.0


### PR DESCRIPTION
Test `#1`, don't restrict `typing_extensions` -- validate-wheelhouse fails
Test `#2`, restrict `typing_extensions<4.0` -- validate-wheelhouse passes