### PR TITLE
make 1.23/stable the default channel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.23/stable"
     description: |
       Snap channel to install Kubernetes master services from
   client_password:

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -34,7 +34,7 @@ applications:
     expose: true
     num_units: 1
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     resources:
       cni-amd64: {{cni_amd64|default("0")}}
       cni-arm64: {{cni_arm64|default("0")}}
@@ -55,7 +55,7 @@ applications:
     expose: true
     num_units: 1
     options:
-      channel: 1.23/edge
+      channel: 1.23/stable
     to:
     - '1'
   prometheus:


### PR DESCRIPTION
In preparation for the 1.23 release, make 1.23/stable the default channel in the `stable` branch.

Drive by to eol `config.yaml`.