### PR TITLE
Fix configure_kubelet missing container-runtime flag

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -3583,7 +3583,11 @@ def default_cni_changed():
     remove_state("kubernetes-master.components.started")
 
 
-@when("kubernetes-master.components.started", "kubernetes-master.apiserver.configured")
+@when(
+    "kubernetes-master.components.started",
+    "kubernetes-master.apiserver.configured",
+    "endpoint.container-runtime.available",
+)
 @when_not("kubernetes-master.kubelet.configured")
 def configure_kubelet():
     uid = hookenv.local_unit()


### PR DESCRIPTION
I saw a hook error / race condition in the recently added configure_kubelet code. The following output is cut off (sorry) but shows the problem clearly enough:

```
unit-kubernetes-master-0: 11:40:36 ERROR unit.kubernetes-master/0.juju-log certificates:7: Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.8/site-packages/charms/reactive/__init__
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.8/site-packages/charms/reactive/bus.py",
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.8/site-packages/charms/reactive/bus.py",
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.8/site-packages/charms/reactive/bus.py",
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/charm/reactive/kubernetes_master.py", line 3618, in config
    kubernetes_common.configure_kubelet(dns_domain, dns_ip, registry, taints=taints)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/charm/lib/charms/layer/kubernetes_common.py", line 1009, i
    kubelet_opts["container-runtime"] = container_runtime.get_runtime()
AttributeError: 'NoneType' object has no attribute 'get_runtime'
```

This happens when [this code](https://github.com/charmed-kubernetes/layer-kubernetes-common/blob/56e7a5513353be6ae6011ae96a53f624480a51bd/lib/charms/layer/kubernetes_common.py#L1007) is called before the container-runtime relation hooks have run.

Easy enough to fix: delay configure_kubelet until `endpoint.container-runtime.available` is set.