### PR TITLE
retry if we fail to create a cohort_key

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -440,7 +440,14 @@ def install_snaps():
 def create_or_update_cohort_keys():
     cohort_keys = {}
     for snapname in cohort_snaps:
-        cohort_key = snap.create_cohort_snapshot(snapname)
+        try:
+            cohort_key = snap.create_cohort_snapshot(snapname)
+        except CalledProcessError:
+            # Snap store outages prevent keys from being created; log it
+            # and retry later. LP:1956608
+            hookenv.log("Failed to create cohort for {}; will retry".format(snapname),
+                        level=hookenv.INFO)
+            return
         cohort_keys[snapname] = cohort_key
     leader_set(cohort_keys=json.dumps(cohort_keys))
     hookenv.log("Snap cohort keys have been created.", level=hookenv.INFO)


### PR DESCRIPTION
A snap store outage caused errors when calling `snap refresh` ([LP 1887973](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1887973), fixed [here](https://github.com/stub42/layer-snap/commit/9c69a33ea0586ac68a4e47d6b55b3a0374b96b26)).

It can also lead to an error when calling `snap create-cohort`.  Handle this by logging a message and letting the function retry on the next reactive loop.

Fixes [LP 1956608](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1956608).